### PR TITLE
Minor Maven improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,16 @@
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-core</artifactId>
             <version>5.3.2</version>
+            <exclusions>
+                <!--
+                dependency-check-core depends indirectly both on commons-logging 1.2 and jcl-over-slf4j 1.7.28
+                as jcl-over-slf4j is a drop-in replacement for commons-logging version 1.2 commons-logging can be exclude
+                 -->
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -92,6 +102,17 @@
             <groupId>org.dizitart</groupId>
             <artifactId>nitrite</artifactId>
             <version>3.4.2</version>
+            <exclusions>
+                <!--
+                h2 includes all classes packaged in h2-mvstore.
+                As h2 is a dependency of dependency-check-core we can exclude h2-mvstore.
+                This allow to avoid conflict when generating shade jar.
+                 -->
+                <exclusion>
+                    <groupId>com.h2database</groupId>
+                    <artifactId>h2-mvstore</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!--        JOOQ        -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,10 @@
 
     <name>vulnerability-producer</name>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.pf4j</groupId>
@@ -26,11 +30,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.30</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.30</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>info.picocli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,10 +27,9 @@
             <version>1.7.30</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.30</version>
-            <scope>test</scope>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
         </dependency>
         <dependency>
             <groupId>info.picocli</groupId>


### PR DESCRIPTION
- Specify the source code encoding to avoid the build to be platform dependent.
- Remove duplicate SLF4J binding: remove `slf4j-log4j12` and keep `slf4j-simple`. Simple outputs all events to System.err.
- Configure the scope of `slf4j-simple` to `test` as slf4j binding is provided by Fasten server.