### PR TITLE
Heuristics to infer PURLs when missing + Handle non-linear version ranges

### DIFF
--- a/src/main/java/eu/fasten/vulnerabilityproducer/VulnerabilityProducer.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/VulnerabilityProducer.java
@@ -204,12 +204,10 @@ class ProducerThread implements Runnable {
     public void run() {
         // Get all the vulnerabilities from the Parsers and enqueue them
         logger.info("Gathering information from all parsers");
-        HashSet<Vulnerability> vulnerabilities = parser.getVulnerabilitiesFromParsers();
+        var vulnerabilities = parser.getVulnerabilitiesFromParsers();
         logger.info("Received a total of " + vulnerabilities.size() + " vulnerabilities from the ParserManager.");
-        for (Vulnerability v : vulnerabilities) {
-            // Add it to the queue to publish to Kafka
-            queue.add(v);
-        }
+        // Add it to the queue to publish to Kafka
+        queue.addAll(vulnerabilities);
 
         // Start a new Thread that checks
         // for updates every day and writes new vulnerabilities
@@ -250,10 +248,9 @@ class UpdaterThread implements Runnable {
                 parser.sleep();
 
                 // Get updates and inject them as well
-                HashSet<Vulnerability> updates = parser.getUpdatesFromParsers();
-                for (Vulnerability v : updates) {
-                    queue.add(v);
-                }
+                var updates = parser.getUpdatesFromParsers();
+                logger.info("Received a total of " + updates.size() + " updates from the ParserManager.");
+                queue.addAll(updates);
             } catch (Exception e) {
                 System.out.println("Could not run updater");
             }

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/PatchFinder.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/PatchFinder.java
@@ -22,14 +22,12 @@ import com.mongodb.client.MongoDatabase;
 import eu.fasten.vulnerabilityproducer.db.NitriteController;
 import eu.fasten.vulnerabilityproducer.db.PatchObject;
 import eu.fasten.vulnerabilityproducer.utils.connections.JavaHttpClient;
-import eu.fasten.vulnerabilityproducer.utils.connections.MongoConnector;
 import eu.fasten.vulnerabilityproducer.utils.patches.*;
 import org.jooq.tools.json.JSONParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
-import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -100,36 +98,36 @@ public class PatchFinder {
      */
     public void parseReferences(Vulnerability vulnerability, NitriteController nc) {
         // Parse all patches and references, scouting for diffs
-        HashSet<String> links = vulnerability.getReferences();
+        var links = vulnerability.getReferences();
         links.addAll(vulnerability.getPatchLinks());
 
         for (String ref : links) {
             // First look into Nitrite if the ref was already parsed before
-            Optional<HashSet<Vulnerability.Patch>> queryFromNC = nc.findPatchEntry(ref);
+            var queryFromNC = nc.findPatchEntry(ref);
             if (!queryFromNC.isEmpty()) {
-                for (Vulnerability.Patch vp : queryFromNC.get()) {
+                queryFromNC.get().forEach(vp -> {
                     vulnerability.addPatch(vp);
-                }
+                    vulnerability.addPatchLink(ref);
+                    vulnerability.getReferences().remove(ref);
+                });
                 continue;
             } else {
-                HashSet<Vulnerability.Patch> vp = parseReference(ref);
+                var vp = parseReference(ref);
 
                 // If something was found, store it in Nitrite and put in it in the Vulnerability
                 if (vp != null && vp.size() > 0) {
                     // Store it in Nitrite
-                    PatchObject po = new PatchObject();
-                    po.setPatchURL(ref);
-                    po.setFilesChanged(vp);
+                    var po = new PatchObject();
+                    po.setPatchURL(ref); po.setFilesChanged(vp);
                     nc.insertPatch(po);
                     logger.info("Found " + vp.size() + " patched files for vulnerability " + vulnerability.getId());
 
                     // Adding patches to the vulnerability
-                    for (Vulnerability.Patch p : vp) {
+                    vp.forEach(p -> {
                         vulnerability.addPatch(p);
-                        // Include the link in the patches links
                         vulnerability.addPatchLink(ref);
                         vulnerability.getReferences().remove(ref);
-                    }
+                    });
                 }
             }
         }
@@ -177,12 +175,12 @@ public class PatchFinder {
         }
 
         // Case 7: Git trackers
-        if (ref.matches("http[s]://.*git\\..*\\.org/.*/commit/.*")) {
+        if (ref.matches("http(s)?://.*git\\..*\\.org/.*/commit/.*")) {
             return extraRanger.parseGitTrackerCommit(ref);
         }
 
         // Case 8: SVN Apache link
-        if (ref.matches("https://svn\\.apache\\.org/.*revision=.*")) {
+        if (ref.matches("http(s)?://svn\\.apache\\.org/(.*revision=.*|r[0-9]++)")) {
             return extraRanger.parseApacheSVNRevision(ref);
         }
 

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/PatchFinder.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/PatchFinder.java
@@ -22,12 +22,14 @@ import com.mongodb.client.MongoDatabase;
 import eu.fasten.vulnerabilityproducer.db.NitriteController;
 import eu.fasten.vulnerabilityproducer.db.PatchObject;
 import eu.fasten.vulnerabilityproducer.utils.connections.JavaHttpClient;
+import eu.fasten.vulnerabilityproducer.utils.connections.MongoConnector;
 import eu.fasten.vulnerabilityproducer.utils.patches.*;
 import org.jooq.tools.json.JSONParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -124,6 +126,9 @@ public class PatchFinder {
                     // Adding patches to the vulnerability
                     for (Vulnerability.Patch p : vp) {
                         vulnerability.addPatch(p);
+                        // Include the link in the patches links
+                        vulnerability.addPatchLink(ref);
+                        vulnerability.getReferences().remove(ref);
                     }
                 }
             }
@@ -224,5 +229,32 @@ public class PatchFinder {
         if (ref.contains("</br>"))   return false;
         if (ref.endsWith("|") || ref.endsWith("]") || ref.endsWith("["))    return false;
         return true;
+    }
+
+    /**
+     * Looks in the patch links for a "repo base" url.
+     * For now handle GitHub links only, since they represent the majority of the base links.
+     * @param v _ Vulnerability Object
+     * @return String with the base url of the repo
+     */
+    public String getBaseRepo(Vulnerability v) {
+        HashMap<String, Integer> mapCounts = new HashMap<>();
+        v.getPatchLinks().stream().filter(ref -> ref.startsWith("https://github.com")).forEach(
+                ref -> mapCounts.merge(getBaseGitHub(ref), 1, Integer::sum)
+        );
+        if (mapCounts.isEmpty())    return null;
+        var mostFreqBase = Collections.max(mapCounts.entrySet(), Map.Entry.comparingByValue()).getKey();
+        return mostFreqBase;
+    }
+
+    /**
+     * Extracts base url of the GitHub repo.
+     * @param ref - link to commit/pr/issue
+     * @return - base url of the repository
+     */
+    private String getBaseGitHub(String ref) {
+        assert ref.contains("github.com");
+        var repoInfo = ref.split("/");
+        return "https://github.com/" + repoInfo[3] + "/" + repoInfo[4];
     }
 }

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/Vulnerability.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/Vulnerability.java
@@ -24,7 +24,7 @@ import eu.fasten.vulnerabilityproducer.utils.mappers.Severity;
 import java.io.Serializable;
 import java.util.*;
 
-public class Vulnerability implements Serializable {
+public class Vulnerability implements Serializable, Comparable<Vulnerability> {
 
     public static class Patch implements Serializable {
         private String fileName;
@@ -373,6 +373,17 @@ public class Vulnerability implements Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(id);
+    }
+
+    @Override
+    public int compareTo(Vulnerability other) {
+        int purlCompare = -1 * Integer.compare(this.getPurls().size(), other.getPurls().size());
+        if (purlCompare == 0) {
+            // Check for patch links
+            return -1 * Integer.compare(this.getPatchLinks().size(), other.getPatchLinks().size());
+        } else {
+            return purlCompare;
+        }
     }
 }
 

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/PurlMapper.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/PurlMapper.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.fasten.vulnerabilityproducer.utils.mappers;
+
+import eu.fasten.vulnerabilityproducer.utils.PatchFinder;
+import eu.fasten.vulnerabilityproducer.utils.Vulnerability;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+import java.util.HashMap;
+import java.util.List;
+
+public class PurlMapper {
+    VersionRanger versionRanger;
+    PatchFinder patchFinder;
+    HashMap<String, String> purlMappings;
+
+    public PurlMapper(VersionRanger versionRanger, PatchFinder patchFinder) {
+        this.versionRanger = versionRanger;
+        this.patchFinder = patchFinder;
+        this.purlMappings = new HashMap<>();
+    }
+
+    /**
+     * Given a vulnerability, it manipulates it to either store or infer mappings.
+     * @param v - Vulnerability object
+     */
+    public void inferPurls(Vulnerability v) {
+        String baseRepo = patchFinder.getBaseRepo(v);
+        if (baseRepo == null)   return;
+
+        // Try to infer purls if missing
+        if (v.getPurls().size() == 0) {
+            if (purlMappings.get(baseRepo) != null) {
+                var basePurl = purlMappings.get(baseRepo);
+                DateTime patchedDate = null;
+                DateTimeFormatter formatter = DateTimeFormat.forPattern("yyyy/mm/dd");
+
+                if (v.getPatches().size() > 0) {
+                    // Look for timestamp of the latest patch
+                    var dateWrapper = new Object(){ DateTime value; };
+                    dateWrapper.value = new DateTime(1950, 1, 1, 0, 0);
+                    v.getPatches().forEach(patch->{
+                        DateTime date = formatter.parseDateTime(patch.getPatchDate());
+                        if (date.isAfter(dateWrapper.value)) {
+                            dateWrapper.value = date;
+                        }
+                    });
+                    patchedDate = dateWrapper.value;
+
+                } else {
+                    if (v.getPublishedDate() == null)   return;
+                    // Else: look for the published_date of the vulnerability
+                    patchedDate = formatter.parseDateTime(v.getPublishedDate());
+                }
+                List<String> inferredPurls = versionRanger.getPurlsBeforeDate(basePurl, patchedDate);
+                inferredPurls.forEach(purl -> v.addPurl(purl));
+            }
+        } else {
+            // Store purl mappings
+            String purlBase = getPurlBase(v);
+            purlMappings.put(baseRepo, purlBase);
+        }
+    }
+
+    private String getPurlBase(Vulnerability v) {
+        assert v.getPurls().size() > 0;
+        var firstPurl = v.getPurls().iterator().next();
+        var base = firstPurl.split("@")[0];
+        assert base != null;
+        return base;
+    }
+}

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/PurlMapper.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/PurlMapper.java
@@ -30,7 +30,7 @@ import java.util.List;
 public class PurlMapper {
     VersionRanger versionRanger;
     PatchFinder patchFinder;
-    HashMap<String, String> purlMappings;
+    public HashMap<String, String> purlMappings;
 
     public PurlMapper(VersionRanger versionRanger, PatchFinder patchFinder) {
         this.versionRanger = versionRanger;
@@ -58,20 +58,22 @@ public class PurlMapper {
                     var dateWrapper = new Object(){ DateTime value; };
                     dateWrapper.value = new DateTime(1950, 1, 1, 0, 0);
                     v.getPatches().forEach(patch->{
-                        DateTime date = formatter.parseDateTime(patch.getPatchDate());
-                        if (date.isAfter(dateWrapper.value)) {
-                            dateWrapper.value = date;
+                        if (patch.getPatchDate() != null) {
+                            DateTime date = formatter.parseDateTime(patch.getPatchDate());
+                            if (date.isAfter(dateWrapper.value)) {
+                                dateWrapper.value = date;
+                            }
                         }
                     });
                     patchedDate = dateWrapper.value;
 
-                } else {
+                } else if (patchedDate == null) {
                     if (v.getPublishedDate() == null)   return;
                     // Else: look for the published_date of the vulnerability
                     patchedDate = formatter.parseDateTime(v.getPublishedDate());
                 }
                 List<String> inferredPurls = versionRanger.getPurlsBeforeDate(basePurl, patchedDate);
-                inferredPurls.forEach(purl -> v.addPurl(purl));
+                inferredPurls.forEach(v::addPurl);
             }
         } else {
             // Store purl mappings
@@ -80,7 +82,12 @@ public class PurlMapper {
         }
     }
 
-    private String getPurlBase(Vulnerability v) {
+    /**
+     * Retrieves the ecosystem and package name from the purls.
+     * @param v - Vulnerability Object storing PURLs.
+     * @return String
+     */
+    public String getPurlBase(Vulnerability v) {
         assert v.getPurls().size() > 0;
         var firstPurl = v.getPurls().iterator().next();
         var base = firstPurl.split("@")[0];

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/VersionRanger.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/VersionRanger.java
@@ -18,30 +18,29 @@
 
 package eu.fasten.vulnerabilityproducer.utils.mappers;
 
+import java.io.*;
 import java.util.*;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.fasten.vulnerabilityproducer.utils.connections.JavaHttpClient;
+import kotlin.Pair;
 import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.jsoup.Jsoup;
 import org.jsoup.select.Elements;
-import org.w3c.dom.*;
-import org.xml.sax.InputSource;
 
-import javax.xml.parsers.*;
-import java.io.*;
+import java.util.stream.Collectors;
 
 public class VersionRanger {
 
     JavaHttpClient client;
-    ObjectMapper mapper;
     // MAVEN encoding: pkg:maven/<group_id>/<artifact_id>
     // PYPI encoding: pkg:pypi/<package_name>
     // DEBIAN encoding: pkg:deb/debian/<package_name>
-    public HashMap<String, List<String>> versionsMappings;
+    public HashMap<String, List<Pair<String, DateTime>>> versionsMappings;
+    public Comparator<Pair<String, DateTime>> versionSorter;
 
     /**
      * Constructor to inject the client
@@ -52,8 +51,13 @@ public class VersionRanger {
      */
     public VersionRanger(JavaHttpClient client, String pathToJson) {
         this.client = client;
-        this.mapper = new ObjectMapper();
         this.versionsMappings = loadVersionsFromJson(pathToJson);
+        this.versionSorter = (o1, o2) -> {
+            if (o1.getSecond() == null || o2.getSecond() == null) {
+                return o1.getFirst().compareTo(o2.getFirst());
+            }
+            return o1.getSecond().compareTo(o2.getSecond());
+        };
     }
 
     /**
@@ -62,14 +66,21 @@ public class VersionRanger {
      * @param path of the JSON file where the versions are stored
      * @return hashmap with the versions already stored
      */
-    public HashMap<String, List<String>> loadVersionsFromJson(String path) {
-        File versions = new File(path);
-        if (versions.exists()) {
+    public HashMap<String, List<Pair<String, DateTime>>> loadVersionsFromJson(String path) {
+        File file = new File(path);
+        if (file.exists()) {
             try {
-                return mapper.readValue(new File(
-                        versions.getPath()), new TypeReference<HashMap<String, List<String>>>() {
-                });
+                FileInputStream fileIn = new FileInputStream(path);
+                ObjectInputStream in = new ObjectInputStream(fileIn);
+                var versions = (HashMap<String, List<Pair<String, DateTime>>>) in.readObject();
+                in.close();
+                fileIn.close();
+                return versions;
+            } catch (FileNotFoundException e) {
+                e.printStackTrace();
             } catch (IOException e) {
+                e.printStackTrace();
+            } catch (ClassNotFoundException e) {
                 e.printStackTrace();
             }
         }
@@ -82,44 +93,33 @@ public class VersionRanger {
      * @param mvnPackage - String that identifies the package to retrieve versions from
      *                   The following format is supported: "/maven/<group_id>/<artifact_id>"
      */
-    public List<String> injectVersionsMavenPackage(String mvnPackage) {
-        String[] splitter = mvnPackage.split("/");
-        String groupId = splitter[2].strip();
-        String artifactId = splitter[3].strip();
-        String[] groupSplits = groupId.split("\\.");
+    public List<Pair<String, DateTime>> injectVersionsMavenPackage(String mvnPackage) {
         StringBuilder sb = new StringBuilder("https://repo1.maven.org/maven2/");
-        for (String gsplit : groupSplits) {
-            sb.append(gsplit + "/");
-        }
-        sb.append(artifactId + "/");
-        sb.append("maven-metadata.xml");
-        String mvnUrl = sb.toString();
-        List<String> versions = new ArrayList<>();
-        try {
-            String details = client.sendGet(mvnUrl);
-            if (details.contains("404 Not Found")) {
-                // This works for some apache packages
-                String clientsUrl = mvnUrl.substring(0, mvnUrl.length() - 19) + "-clients/maven-metadata.xml";
-                details = client.sendGet(clientsUrl);
-                if (details.contains("404 Not Found")) {
-                    return null;
-                }
-            }
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            DocumentBuilder builder = factory.newDocumentBuilder();
-            Document document = builder.parse(new InputSource(new StringReader(details)));
-            Element root = document.getDocumentElement();
-            NodeList versionsNodes = root.getElementsByTagName("version");
-            for (int i = 0; i < versionsNodes.getLength(); i++) {
-                String version = versionsNodes.item(i).getTextContent();
-                versions.add(version);
-            }
-            versionsMappings.put(mvnPackage, versions);
-            return versions;
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return null;
+        var splitter = mvnPackage.split("/");
+        var groupId = splitter[2].strip();
+        var artifactId = splitter[3].strip();
+        Arrays.stream(groupId.split("\\.")).forEach(x -> sb.append(x).append("/"));
+        sb.append(artifactId + "");
+
+        DateTimeFormatter formatter = DateTimeFormat.forPattern("yyyy-mm-dd");
+        var url = sb.toString();
+        var html = client.sendGet(url);
+        if (html.contains("404 Not Found")) html = client.sendGet(url.substring(0, url.length() - 19) + "-clients");
+        if (html.contains("404 Not Found")) return null;
+
+        var doc = Jsoup.parse(html);
+        var content = doc.select("pre").first();
+        List<Pair<String, DateTime>> versions = new ArrayList<>();
+        Arrays.stream(content.toString().split("\n"))
+                .filter(s -> s.trim().endsWith("-"))
+                .forEach(s -> {
+                    var version = s.substring(s.indexOf('"') + 1, s.indexOf('/'));
+                    var timestamp = formatter.parseDateTime(s.split("\\s++")[3]);
+                    versions.add(new Pair<>(version, timestamp));
+                });
+        Collections.sort(versions, versionSorter);
+        versionsMappings.put(mvnPackage, versions);
+        return versions;
     }
 
     /**
@@ -128,28 +128,29 @@ public class VersionRanger {
      * @param pypiPackage - String that identifies the package to retrieve versions from
      *                    The following format is supported: "/pypi/<package_name>"
      */
-    public List<String> injectVersionsPyPiPackage(String pypiPackage) {
-        String[] splitter = pypiPackage.split("/");
-        List<String> versions = new ArrayList<>();
-        String packageName = splitter[2].strip();
-        try {
-            String details = client.sendGet("https://pypi.org/pypi/" + packageName + "/json");
-            if (details.contains("We looked everywhere but couldn't find this page") || details.contains("404 Not Found")) {
-                return null;
+    public List<Pair<String, DateTime>> injectVersionsPyPiPackage(String pypiPackage) {
+
+        List<Pair<String, DateTime>> versions = new ArrayList<>();
+        DateTimeFormatter formatter = DateTimeFormat.forPattern("yyyy-mm-dd'T'HH:mm:ss");
+
+        var details = client.sendGet("https://pypi.org/pypi/" + pypiPackage.split("/")[2].strip() + "/json");
+        if (details.contains("We looked everywhere but couldn't find this page") || details.contains("404 Not Found")) System.out.println("yikes");
+
+        var obj = new JSONObject(details);
+        var releases = obj.getJSONObject("releases");
+        releases.keySet().forEach(key -> {
+            var info = releases.getJSONArray(key);
+            if (info.length() == 0) versions.add(new Pair(key, null));
+            else {
+                var pkgInfo = (JSONObject) info.get(0);
+                var timestamp = pkgInfo.get("upload_time") != null ? formatter.parseDateTime(pkgInfo.get("upload_time").toString()) : null;
+                versions.add(new Pair(key, timestamp));
             }
-            JSONObject obj = new JSONObject(details);
-            // TreeSet keeps versions sorted
-            TreeSet<String> releases = new TreeSet(obj.getJSONObject("releases").keySet());
-            for (String s : releases) {
-                versions.add(s);
-            }
-            Collections.sort(versions);
-            versionsMappings.put(pypiPackage, versions);
-            return versions;
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return null;
+        });
+
+        Collections.sort(versions, versionSorter);
+        versionsMappings.put(pypiPackage, versions);
+        return versions;
     }
 
     /**
@@ -173,7 +174,6 @@ public class VersionRanger {
             versions = versions.subList(2, versions.size());
             // Reverse the list
             Collections.reverse(versions);
-            versionsMappings.put(debPackage, versions);
             return versions;
         } catch (Exception e) {
             e.printStackTrace();
@@ -187,9 +187,9 @@ public class VersionRanger {
      * @param debPackage - String that identifies the package to retrieve versions from
      *                   The following format is supported: "/deb/debian/<pkg_name>"
      */
-    public List<String> injectVersionsDebianPackage(String debPackage) {
+    public List<Pair<String, DateTime>> injectVersionsDebianPackage(String debPackage) {
         try {
-            List<String> versions = new ArrayList<>();
+            List<Pair<String, DateTime>> versions = new ArrayList<>();
             String url = "https://sources.debian.org/api/src/" + debPackage.substring(12) + "/";
             String rawJSON = client.sendGet(url);
             // Check if 404 or non-existing
@@ -201,14 +201,14 @@ public class VersionRanger {
 
             for (int i = 0, size = versionsArray.length(); i < size; i++) {
                 JSONObject versionObj = versionsArray.getJSONObject(i);
-                List<Object> releases = (List<Object>) ((JSONArray) versionObj.get("suites")).toList();
+                List<Object> releases = ((JSONArray) versionObj.get("suites")).toList();
                 if (releases.contains("buster")) {
-                    versions.add((String) versionObj.get("version"));
+                    versions.add(new Pair(versionObj.get("version"), null));
                 }
             }
 
             // Sort the list
-            Collections.sort(versions);
+            Collections.sort(versions, versionSorter);
             versionsMappings.put(debPackage, versions);
             return versions;
         } catch (Exception e) {
@@ -336,13 +336,8 @@ public class VersionRanger {
      * @return list of vulnerable versions
      */
     public List<String> getVulnerableVersionsOVAL(String lessThanVersion, List<String> versions) {
-        List<String> dummy = new ArrayList<>();
-        int indexVulnerable = versions.indexOf(lessThanVersion);
-        if (indexVulnerable > 0) {
-            return versions.subList(0, indexVulnerable);
-        } else {
-            return dummy;
-        }
+        var indexVulnerable = versions.indexOf(lessThanVersion);
+        return indexVulnerable > 0 ? versions.subList(0, indexVulnerable) : new ArrayList<>();
     }
 
     /**
@@ -352,10 +347,12 @@ public class VersionRanger {
      * @return - String list with all the purls found before the indicated date
      */
     public List<String> getPurlsBeforeDate(String basePurl, DateTime date) {
-        List<String> purls = new ArrayList<>();
-        // TODO: Refactor the entire retrieval for Maven and Pypi to store dates as well
-        // Store a Pair<String, DateTime> where each version is mapped to its release date
-        return purls;
+        if (date == null)   return new ArrayList<>();
+        assert versionsMappings.get(basePurl) != null;
+        return versionsMappings.get(basePurl).stream()
+                .filter(version -> version.getSecond().isBefore(date))
+                .map(pair -> basePurl + "@" + pair.getFirst())
+                .collect(Collectors.toList());
     }
 
     /**
@@ -407,16 +404,16 @@ public class VersionRanger {
      */
     public List<String> getVersions(String pgk) {
         if (versionsMappings.get(pgk) != null) {
-            return versionsMappings.get(pgk);
+            return versionsMappings.get(pgk).stream().map(Pair::getFirst).collect(Collectors.toList());
         }
         if (pgk.matches("/maven/.*")) {
-            return injectVersionsMavenPackage(pgk);
+            return injectVersionsMavenPackage(pgk).stream().map(Pair::getFirst).collect(Collectors.toList());
         }
         if (pgk.matches("/pypi/.*")) {
-            return injectVersionsPyPiPackage(pgk);
+            return injectVersionsPyPiPackage(pgk).stream().map(Pair::getFirst).collect(Collectors.toList());
         }
         if (pgk.matches("/deb/debian/.*")) {
-            return injectVersionsDebianPackage(pgk);
+            return injectVersionsDebianPackage(pgk).stream().map(Pair::getFirst).collect(Collectors.toList());
         }
         return null;
     }
@@ -427,11 +424,15 @@ public class VersionRanger {
      *                    e.g. "./analyzer/vulnerability-plugin/src/main/resources/trackers/package_versions.json"
      */
     public void writeVersions(String pathToWrite) {
-        ObjectMapper mapper = new ObjectMapper();
         try {
-            mapper.writeValue(new File(pathToWrite), versionsMappings);
-        } catch (IOException e) {
-            e.printStackTrace();
+            FileOutputStream fileOut =
+                    new FileOutputStream(pathToWrite);
+            ObjectOutputStream out = new ObjectOutputStream(fileOut);
+            out.writeObject(versionsMappings);
+            out.close();
+            fileOut.close();
+        } catch (IOException i) {
+            i.printStackTrace();
         }
     }
 

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/VersionRanger.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/VersionRanger.java
@@ -23,6 +23,7 @@ import java.util.*;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.fasten.vulnerabilityproducer.utils.connections.JavaHttpClient;
+import org.joda.time.DateTime;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.jsoup.Jsoup;
@@ -342,6 +343,19 @@ public class VersionRanger {
         } else {
             return dummy;
         }
+    }
+
+    /**
+     * Given a base PURL and a date
+     * @param basePurl - package coordinates
+     * @param date - date to find purls before
+     * @return - String list with all the purls found before the indicated date
+     */
+    public List<String> getPurlsBeforeDate(String basePurl, DateTime date) {
+        List<String> purls = new ArrayList<>();
+        // TODO: Refactor the entire retrieval for Maven and Pypi to store dates as well
+        // Store a Pair<String, DateTime> where each version is mapped to its release date
+        return purls;
     }
 
     /**

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
@@ -69,10 +69,6 @@ public class ParserManager {
         this.nitriteController = nitriteController;
     }
 
-    public void setGhToken(String ghToken) {
-        this.ghToken = ghToken;
-    }
-
     /**
      * Combines the results of all the parsers.
      *
@@ -80,13 +76,13 @@ public class ParserManager {
      */
     public HashSet<Vulnerability> getVulnerabilitiesFromParsers() {
         logger.info("Gathering vulnerabilities from GitHub Advisories");
-        HashMap<String, Vulnerability> mapFromGH = ghParser.getVulnerabilities();
+        var mapFromGH = ghParser.getVulnerabilities();
         logger.info("Gathering vulnerabilities from Extra Sources");
-        HashMap<String, Vulnerability> mapFromExtraSources = extraParser.getVulnerabilities();
+        var mapFromExtraSources = extraParser.getVulnerabilities();
         logger.info("Gathering vulnerabilities from NVD");
-        HashMap<String, Vulnerability> mapFromNVD = nvdParser.getVulnerabilities();
+        var mapFromNVD = nvdParser.getVulnerabilities();
         logger.info("Gathering vulnerabilities from Debian OVAL");
-        HashMap<String, Vulnerability> mapFromOVAL = ovalParser.getVulnerabilities();
+        var mapFromOVAL = ovalParser.getVulnerabilities();
 
         logger.info("Merging all the pulled vulnerabilities");
         // Put all maps from parsers into a list to pass it on
@@ -95,26 +91,30 @@ public class ParserManager {
         maps.add(mapFromExtraSources);
         maps.add(mapFromGH);
         maps.add(mapFromOVAL);
-        HashSet<Vulnerability> vulnerabilities = mergeMapsOfVulnerabilities(maps);
+        var vulnerabilities = mergeMapsOfVulnerabilities(maps);
 
         logger.info("Injecting information about Patches");
-        for (Vulnerability v : vulnerabilities) {
+        var vulnSet = new HashSet<Vulnerability>();
+        while (!vulnerabilities.isEmpty()) {
+            var v = vulnerabilities.poll();
             // Adding patch information
             patchFinder.parseReferences(v, nitriteController);
             // Infer purls
             purlMapper.inferPurls(v);
             // Store statement
-            storeVulnJson(v);
+            // storeVulnJson(v);
+            // Add it to the set
+            vulnSet.add(v);
         }
 
-        filterNewEntries(vulnerabilities);
+        filterNewEntries(vulnSet);
 
-        return vulnerabilities;
+        return vulnSet;
     }
 
     public static void storeVulnJson(Vulnerability v) {
         // Storing the file to statements
-        File file = new File("/path/to/di0r/" + v.getId() + ".json");
+        File file = new File("/path/to/dir/" + v.getId() + ".json");
         try {
             FileUtils.writeStringToFile(file, v.toJson());
         } catch (IOException e) {
@@ -147,18 +147,26 @@ public class ParserManager {
         maps.add(mapFromExtraSources);
         maps.add(mapFromGH);
         maps.add(mapFromOVAL);
-        HashSet<Vulnerability> vulnerabilities = mergeMapsOfVulnerabilities(maps);
+        var vulnerabilities = mergeMapsOfVulnerabilities(maps);
 
         logger.info("Parsing references of all vulnerabilities to inject patches information");
-        for (Vulnerability v : vulnerabilities) {
-            logger.info("Parsing references from Vulnerability with ID: " + v.getId());
+        var vulnSet = new HashSet<Vulnerability>();
+        while (!vulnerabilities.isEmpty()) {
+            var v = vulnerabilities.poll();
+            // Adding patch information
             patchFinder.parseReferences(v, nitriteController);
+            // Infer purls
+            purlMapper.inferPurls(v);
+            // Store statement
+            // storeVulnJson(v);
+            // Add it to the set
+            vulnSet.add(v);
         }
 
         logger.info("Filtering if entries are new using Nitrite Controller");
-        filterNewEntries(vulnerabilities);
+        filterNewEntries(vulnSet);
 
-        return vulnerabilities;
+        return vulnSet;
     }
 
     /**
@@ -168,14 +176,14 @@ public class ParserManager {
      * @param vulnerabilities - cleaned containing only new ones.
      */
     private void filterNewEntries(HashSet<Vulnerability> vulnerabilities) {
-        for (Vulnerability v : vulnerabilities) {
-            Optional<Vulnerability> queryFromNC = nitriteController.findVulnerabilityEntry(v.getId());
-            if (!queryFromNC.isEmpty()) {
+        vulnerabilities.forEach(v -> {
+            var queryFromNC = nitriteController.findVulnerabilityEntry(v.getId());
+            if (queryFromNC.isPresent()) {
                 if (queryFromNC.get().equals(v)) {
                     vulnerabilities.remove(v);
                 }
             }
-        }
+        });
     }
 
 
@@ -184,7 +192,7 @@ public class ParserManager {
      * @param maps - List of hashmaps mapping ID to Vulnerability objects
      * @return set of vulnerabilities
      */
-    private HashSet<Vulnerability> mergeMapsOfVulnerabilities(List<HashMap<String, Vulnerability>> maps) {
+    private PriorityQueue<Vulnerability> mergeMapsOfVulnerabilities(List<HashMap<String, Vulnerability>> maps) {
         HashMap<String, Vulnerability> mapMerger = new HashMap<>();
         for (HashMap<String, Vulnerability> map : maps) {
             for (String vulnerabilityId : map.keySet()) {
@@ -197,7 +205,7 @@ public class ParserManager {
                 }
             }
         }
-        HashSet<Vulnerability> vulnerabilities = new HashSet<>(mapMerger.values());
+        var vulnerabilities = new PriorityQueue<>(mapMerger.values());
         return vulnerabilities;
     }
 

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
@@ -23,6 +23,7 @@ import eu.fasten.vulnerabilityproducer.db.NitriteController;
 import eu.fasten.vulnerabilityproducer.utils.PatchFinder;
 import eu.fasten.vulnerabilityproducer.utils.Vulnerability;
 import eu.fasten.vulnerabilityproducer.utils.connections.JavaHttpClient;
+import eu.fasten.vulnerabilityproducer.utils.mappers.PurlMapper;
 import eu.fasten.vulnerabilityproducer.utils.mappers.VersionRanger;
 import org.apache.commons.io.FileUtils;
 import org.jooq.tools.json.JSONParser;
@@ -48,6 +49,7 @@ public class ParserManager {
     private PatchFinder patchFinder;
     private VersionRanger versionRanger;
     private NitriteController nitriteController;
+    private PurlMapper purlMapper;
     private final Logger logger = LoggerFactory.getLogger(ParserManager.class.getName());
 
     private String pathToVersions = "./src/main/resources/trackers/package_versions.json";
@@ -63,6 +65,7 @@ public class ParserManager {
         this.ghParser = new GHParser(client, ghToken, versionRanger, pathToGHCursor);
         this.nvdParser = new NVDParser(new JSONParser(), client);
         this.patchFinder = new PatchFinder(mongoDatabase, client);
+        this.purlMapper = new PurlMapper(versionRanger, patchFinder);
         this.nitriteController = nitriteController;
     }
 
@@ -98,13 +101,10 @@ public class ParserManager {
         for (Vulnerability v : vulnerabilities) {
             // Adding patch information
             patchFinder.parseReferences(v, nitriteController);
-            // Storing the file to statements
-            File file = new File("/Users/Edo/Desktop/statements/" + v.getId() + ".json");
-            try {
-                FileUtils.writeStringToFile(file, v.toJson());
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+            // Infer purls
+            purlMapper.inferPurls(v);
+            // Store statement
+            storeVulnJson(v);
         }
 
         filterNewEntries(vulnerabilities);
@@ -112,6 +112,15 @@ public class ParserManager {
         return vulnerabilities;
     }
 
+    public static void storeVulnJson(Vulnerability v) {
+        // Storing the file to statements
+        File file = new File("/path/to/di0r/" + v.getId() + ".json");
+        try {
+            FileUtils.writeStringToFile(file, v.toJson());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 
     /**
      * Get updates from all the different parsers and return them.

--- a/src/test/java/eu/fasten/vulnerabilityproducer/PatchFinderTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/PatchFinderTest.java
@@ -998,5 +998,19 @@ public class PatchFinderTest {
 
         assertEquals(patches_exp, v.getPatches());
     }
+
+    @Test
+    public void testGetGithubBaseRepo() {
+        var ref1 = "https://github.com/fasten-project/vulnerability-producer/commit/e357a6740dbd96a6412c0810228124aa8db91212";
+        var ref2 = "https://github.com/fasten-project/vulnerability-producer/issue/3";
+        var ref3 = "https://github.com/fasten-project/fasten/issues/33";
+        Vulnerability v = new Vulnerability("TEST");
+        v.addPatchLink(ref1);
+        v.addPatchLink(ref2);
+        v.addPatchLink(ref3);
+
+        var repoBase = patchFinder.getBaseRepo(v);
+        assertEquals("https://github.com/fasten-project/vulnerability-producer", repoBase);
+    }
 }
 

--- a/src/test/java/eu/fasten/vulnerabilityproducer/PatchFinderTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/PatchFinderTest.java
@@ -166,7 +166,7 @@ public class PatchFinderTest {
         patchFinder = new PatchFinder(dbMock, clientMock);
     }
 
-    public String readFile(String filePath) throws IOException {
+    public static String readFile(String filePath) throws IOException {
         File file = new File(filePath);
         return FileUtils.readFileToString(file, StandardCharsets.UTF_8);
     }

--- a/src/test/java/eu/fasten/vulnerabilityproducer/VulnerabilityProducerTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/VulnerabilityProducerTest.java
@@ -27,10 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -67,7 +64,8 @@ public class VulnerabilityProducerTest {
             // Set the producer thread with the parserMock
             ProducerThread prt = new ProducerThread(vulnerabilityProducer.getQueue(), parserMock);
             vulnerabilityProducer.setProducerThread(prt);
-            vulnerabilityProducer.getProducerThread().start();
+            vulnerabilityProducer.getProducerThread()
+                    .start();
 
             // Wait for ut to be initialized and terminate updater
             sleep(1);

--- a/src/test/java/eu/fasten/vulnerabilityproducer/mappers/PurlMapperTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/mappers/PurlMapperTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.fasten.vulnerabilityproducer.mappers;
+
+import eu.fasten.vulnerabilityproducer.utils.PatchFinder;
+import eu.fasten.vulnerabilityproducer.utils.mappers.PurlMapper;
+import eu.fasten.vulnerabilityproducer.utils.mappers.VersionRanger;
+import org.mockito.Mockito;
+
+public class PurlMapperTest {
+
+    VersionRanger vrMock = Mockito.mock(VersionRanger.class);
+    PatchFinder pfMock = Mockito.mock(PatchFinder.class);
+    PurlMapper purlMapper = new PurlMapper(vrMock, pfMock);
+
+
+
+}

--- a/src/test/java/eu/fasten/vulnerabilityproducer/mappers/PurlMapperTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/mappers/PurlMapperTest.java
@@ -19,9 +19,23 @@
 package eu.fasten.vulnerabilityproducer.mappers;
 
 import eu.fasten.vulnerabilityproducer.utils.PatchFinder;
+import eu.fasten.vulnerabilityproducer.utils.Vulnerability;
 import eu.fasten.vulnerabilityproducer.utils.mappers.PurlMapper;
 import eu.fasten.vulnerabilityproducer.utils.mappers.VersionRanger;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.booleanThat;
+import static org.mockito.Mockito.when;
 
 public class PurlMapperTest {
 
@@ -29,6 +43,40 @@ public class PurlMapperTest {
     PatchFinder pfMock = Mockito.mock(PatchFinder.class);
     PurlMapper purlMapper = new PurlMapper(vrMock, pfMock);
 
+    @Test
+    public void getBasePurlTest() {
+        Vulnerability v = new Vulnerability();
+        v.addPurl("pkg:pypi/django@1.9");
+        v.addPurl("pkg:pypi/django@1.9.1");
+        v.addPurl("pkg:pypi/django@1.9.2");
 
+        assertEquals("pkg:pypi/django", purlMapper.getPurlBase(v));
+    }
 
+    @Test
+    public void inferPurlStoring() {
+        Vulnerability v = new Vulnerability();
+        v.addPurl("pkg:pypi/django@1.9");
+        v.addPatchLink("https;//github.com/python/django/commit/5326bi6b5u53b1u5ob1b5i265");
+
+        when(pfMock.getBaseRepo(v)).thenReturn("https://github.com/python/django");
+
+        purlMapper.inferPurls(v);
+        assertEquals("pkg:pypi/django", purlMapper.purlMappings.get("https://github.com/python/django"));
+    }
+
+    @Test
+    public void inferPurlMissing() {
+        purlMapper.purlMappings.put("https://github.com/python/django", "pkg:pypi/django");
+        var versions = new ArrayList<String>(); versions.add("pkg:pypi/django@1.9");
+        Vulnerability v = new Vulnerability();
+        v.addPatchLink("https//github.com/python/django/commit/5326bi6b5u53b1u5ob1b5i265");
+        v.addPatch(new Vulnerability.Patch("oof.py", "2018/05/30",  null ));
+
+        when(vrMock.getPurlsBeforeDate(Mockito.anyString(), Mockito.any())).thenReturn(versions);
+        when(pfMock.getBaseRepo(v)).thenReturn("https://github.com/python/django");
+
+        purlMapper.inferPurls(v);
+        assertTrue(v.getPurls().contains("pkg:pypi/django@1.9"));
+    }
 }

--- a/src/test/java/eu/fasten/vulnerabilityproducer/mappers/VersionRangerTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/mappers/VersionRangerTest.java
@@ -18,10 +18,14 @@
 
 package eu.fasten.vulnerabilityproducer.mappers;
 
+import eu.fasten.vulnerabilityproducer.PatchFinderTest;
+import eu.fasten.vulnerabilityproducer.utils.PatchFinder;
 import eu.fasten.vulnerabilityproducer.utils.connections.JavaHttpClient;
 import eu.fasten.vulnerabilityproducer.utils.mappers.VersionRanger;
 import eu.fasten.vulnerabilityproducer.utils.mappers.YAMLHandler;
+import kotlin.Pair;
 import org.apache.commons.io.FileUtils;
+import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
@@ -30,6 +34,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
@@ -43,57 +48,11 @@ public class VersionRangerTest {
     String path = "./src/test/resources/test_versions.json";
     VersionRanger vr = new VersionRanger(clientMock, path);
 
-    String xlmResponseKafka = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-            "<metadata>\n" +
-            "  <groupId>org.apache.kafka</groupId>\n" +
-            "  <artifactId>kafka-clients</artifactId>\n" +
-            "  <versioning>\n" +
-            "    <latest>2.5.0</latest>\n" +
-            "    <release>2.5.0</release>\n" +
-            "    <versions>\n" +
-            "      <version>0.8.2-beta</version>\n" +
-            "      <version>0.8.2.0</version>\n" +
-            "      <version>0.8.2.1</version>\n" +
-            "      <version>0.8.2.2</version>\n" +
-            "      <version>0.9.0.0</version>\n" +
-            "      <version>0.9.0.1</version>\n" +
-            "      <version>0.10.0.0</version>\n" +
-            "      <version>0.10.0.1</version>\n" +
-            "      <version>0.10.1.0</version>\n" +
-            "      <version>0.10.1.1</version>\n" +
-            "      <version>0.10.2.0</version>\n" +
-            "      <version>0.10.2.1</version>\n" +
-            "      <version>0.10.2.2</version>\n" +
-            "      <version>0.11.0.0</version>\n" +
-            "      <version>0.11.0.1</version>\n" +
-            "      <version>0.11.0.2</version>\n" +
-            "      <version>0.11.0.3</version>\n" +
-            "      <version>1.0.0</version>\n" +
-            "      <version>1.0.1</version>\n" +
-            "      <version>1.0.2</version>\n" +
-            "      <version>1.1.0</version>\n" +
-            "      <version>1.1.1</version>\n" +
-            "      <version>2.0.0</version>\n" +
-            "      <version>2.0.1</version>\n" +
-            "      <version>2.1.0</version>\n" +
-            "      <version>2.1.1</version>\n" +
-            "      <version>2.2.0</version>\n" +
-            "      <version>2.2.1</version>\n" +
-            "      <version>2.2.2</version>\n" +
-            "      <version>2.3.0</version>\n" +
-            "      <version>2.3.1</version>\n" +
-            "      <version>2.4.0</version>\n" +
-            "      <version>2.4.1</version>\n" +
-            "      <version>2.5.0</version>\n" +
-            "    </versions>\n" +
-            "    <lastUpdated>20200414202502</lastUpdated>\n" +
-            "  </versioning>\n" +
-            "</metadata>";
+    static String jsonResponseDjango;
 
-    String jsonResponseDjango;
-    {
+    static {
         try {
-            jsonResponseDjango = FileUtils.readFileToString(new File("./src/test/resources/version_handling/django_versions.json"), StandardCharsets.UTF_8);
+            jsonResponseDjango = PatchFinderTest.readFile("./src/test/resources/version_handling/django_versions.json");
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -143,7 +102,8 @@ public class VersionRangerTest {
 
         VersionRanger vr1 = new VersionRanger(clientMock, path);
 
-        when(clientMock.sendGet("https://repo1.maven.org/maven2/org/apache/kafka/kafka/maven-metadata.xml")).thenReturn(xlmResponseKafka);
+        var htmlResponseKafka = PatchFinderTest.readFile("./src/test/resources/version_handling/html_kafka.htm");
+        when(clientMock.sendGet("https://repo1.maven.org/maven2/org/apache/kafka/kafka")).thenReturn(htmlResponseKafka);
         when(clientMock.sendGet("https://pypi.org/pypi/django/json")).thenReturn(jsonResponseDjango);
 
         vr1.getVersions("/maven/org.apache.kafka/kafka");
@@ -156,11 +116,6 @@ public class VersionRangerTest {
         assertTrue(vr2.versionsMappings.get("/maven/org.apache.kafka/kafka").size() > 0);
 
         FileUtils.deleteQuietly(new File(path));
-    }
-
-    @Test
-    public void testVulnerableVersionsYAML() {
-
     }
 
     @Test
@@ -276,7 +231,7 @@ public class VersionRangerTest {
     public void testInjectDebianPackageJSON() throws Exception {
         when(clientMock.sendGet("https://sources.debian.org/api/src/libpcap/")).thenReturn(jsonDebian);
 
-        List<String> versions = vr.injectVersionsDebianPackage("/deb/debian/libpcap");
+        List<String> versions = vr.getVersions("/deb/debian/libpcap");
         assertTrue(versions.contains("1.8.1-6"));
     }
 
@@ -300,7 +255,6 @@ public class VersionRangerTest {
         assertEquals(expectedResult, result);
     }
 
-
     @Test
     public void testRangeVersionsDebianBadWeather() {
         String lessThanVersion = "0.9.4";
@@ -313,5 +267,18 @@ public class VersionRangerTest {
         allVersions.add("0.9.5");
         List<String> result = vr.getVulnerableVersionsOVAL(lessThanVersion, allVersions);
         assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testGetVersionsBeforeDate() {
+        var versions = new ArrayList<Pair<String, DateTime>>();
+        versions.add(new Pair("1.8", new DateTime(2018, 7, 24, 0, 0)));
+        versions.add(new Pair("1.9", new DateTime(2019, 7, 24, 0, 0)));
+
+        vr.versionsMappings.put("pkg:pypi/django", versions);
+        var actual = vr.getPurlsBeforeDate("pkg:pypi/django", new DateTime(2018, 12, 30, 0, 0));
+        var expected = new ArrayList<>(Arrays.asList("pkg:pypi/django@1.8"));
+
+        assertEquals(expected, actual);
     }
 }

--- a/src/test/java/eu/fasten/vulnerabilityproducer/parsers/ExtraParserTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/parsers/ExtraParserTest.java
@@ -24,8 +24,10 @@ import eu.fasten.vulnerabilityproducer.utils.connections.JavaHttpClient;
 import eu.fasten.vulnerabilityproducer.utils.mappers.VersionRanger;
 import eu.fasten.vulnerabilityproducer.utils.mappers.YAMLHandler;
 import eu.fasten.vulnerabilityproducer.utils.parsers.ExtraParser;
+import kotlin.Pair;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.builder.ToStringExclude;
+import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -34,10 +36,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -88,7 +88,7 @@ public class ExtraParserTest {
 
     @Test
     public void testInjectFromSafetyDB() throws Exception {
-        List<String> mockVersions = Arrays.asList("0.9", "1.0", "1.1", "1.2");
+        List mockVersions = Arrays.asList("0.9", "1.0", "1.1", "1.2").stream().map(x -> new Pair(x, null)).collect(Collectors.toList());
         extraParser.getVersionRanger().versionsMappings.put("/pypi/mock", mockVersions);
 
         when(clientMock.sendGet("https://raw.githubusercontent.com/pyupio/safety-db/master/data/insecure_full.json")).thenReturn(insecureJsonMock);
@@ -126,8 +126,11 @@ public class ExtraParserTest {
 
     @Test
     public void testInjectYAMLSource() {
-        extraParser.getVersionRanger().versionsMappings.put("/maven/org.mock/testing", Arrays.asList("2.0.0", "2.0.1.RELEASE"));
-        extraParser.getVersionRanger().versionsMappings.put("/pypi/mock", Arrays.asList("0.2.2", "0.3.4"));
+        var versionsA = new ArrayList<Pair<String, DateTime>>(); Arrays.asList("2.0.0", "2.0.1.RELEASE").forEach(x -> versionsA.add(new Pair(x, null)));
+        var versionsB = new ArrayList<Pair<String, DateTime>>(); Arrays.asList("0.2.2", "0.3.4").forEach(x -> versionsA.add(new Pair(x, null)));
+
+        extraParser.getVersionRanger().versionsMappings.put("/maven/org.mock/testing", versionsA);
+        extraParser.getVersionRanger().versionsMappings.put("/pypi/mock", versionsB);
 
         Vulnerability vJava = new Vulnerability("CVE-2020-0001");
         vJava.setDescription("mock java");

--- a/src/test/java/eu/fasten/vulnerabilityproducer/parsers/GHParserTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/parsers/GHParserTest.java
@@ -23,7 +23,9 @@ import eu.fasten.vulnerabilityproducer.utils.connections.JavaHttpClient;
 import eu.fasten.vulnerabilityproducer.utils.mappers.Severity;
 import eu.fasten.vulnerabilityproducer.utils.mappers.VersionRanger;
 import eu.fasten.vulnerabilityproducer.utils.parsers.GHParser;
+import kotlin.Pair;
 import org.apache.commons.io.FileUtils;
+import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -32,8 +34,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -130,7 +134,7 @@ public class GHParserTest {
         HashMap<String, String> values = new HashMap<>();
         values.put("query", queryNoCursor);
         when(clientMock.sendPost("https://api.github.com/graphql", token, values)).thenReturn(ghResponseAPI);
-        List<String> versions = Arrays.asList("1.3.2", "1.4.9", "1.4.10", "1.4.12");
+        List versions = Arrays.asList("1.3.2", "1.4.9", "1.4.10", "1.4.12").stream().map(x -> new Pair(x, null)).collect(Collectors.toList());
         ghParser.getVersionRanger().versionsMappings.put("/maven/com.thoughtworks.xstream/xstream", versions);
         ghParser.setCursor(null);
 

--- a/src/test/java/eu/fasten/vulnerabilityproducer/parsers/OVALParserTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/parsers/OVALParserTest.java
@@ -22,7 +22,9 @@ import eu.fasten.vulnerabilityproducer.utils.Vulnerability;
 import eu.fasten.vulnerabilityproducer.utils.connections.JavaHttpClient;
 import eu.fasten.vulnerabilityproducer.utils.mappers.VersionRanger;
 import eu.fasten.vulnerabilityproducer.utils.parsers.OVALParser;
+import kotlin.Pair;
 import org.apache.commons.io.FileUtils;
+import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -30,6 +32,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
@@ -70,8 +73,12 @@ public class OVALParserTest {
         versionsKRB5.add("1.1");
         versionsKRB5.add("1.2");
 
-        vr.versionsMappings.put("/deb/debian/a2ps", versionsA2PS);
-        vr.versionsMappings.put("/deb/debian/krb5", versionsKRB5);
+        var versionsA = new ArrayList<Pair<String, DateTime>>();
+        versionsA2PS.forEach(x -> versionsA.add(new Pair(x, null)));
+        var versionsB = new ArrayList<Pair<String, DateTime>>();
+        versionsKRB5.forEach(x -> versionsB.add(new Pair(x, null)));
+        vr.versionsMappings.put("/deb/debian/a2ps", versionsA);
+        vr.versionsMappings.put("/deb/debian/krb5", versionsB);
 
         // Construct the object that will be parsed
         Vulnerability v1 = new Vulnerability("CVE-2001-1593");

--- a/src/test/java/eu/fasten/vulnerabilityproducer/parsers/ParserManagerTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/parsers/ParserManagerTest.java
@@ -99,7 +99,7 @@ public class ParserManagerTest {
         when(extraParserMock.getVulnerabilities()).thenReturn(extraVulns);
         when(ovalParserMock.getVulnerabilities()).thenReturn(ovalVulns);
 
-        HashSet<Vulnerability> check = pm.getVulnerabilitiesFromParsers();
+        var check = pm.getVulnerabilitiesFromParsers();
         // EXPECTED
         HashSet<Vulnerability> expected = new HashSet<>();
         Vulnerability vE1 = new Vulnerability("CVE-TEST-1");
@@ -161,7 +161,7 @@ public class ParserManagerTest {
         when(extraParserMock.getUpdates()).thenReturn(extraVulns);
         when(ovalParserMock.getUpdates()).thenReturn(ovalVulns);
 
-        HashSet<Vulnerability> check = pm.getUpdatesFromParsers();
+        var check = pm.getUpdatesFromParsers();
 
         // EXPECTED
         HashSet<Vulnerability> expected = new HashSet<>();

--- a/src/test/resources/version_handling/html_kafka.htm
+++ b/src/test/resources/version_handling/html_kafka.htm
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>Central Repository: org/apache/kafka/kafka-clients</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<style>
+body {
+	background: #fff;
+}
+	</style>
+</head>
+
+<body>
+	<header>
+		<h1>org/apache/kafka/kafka-clients</h1>
+	</header>
+	<hr/>
+	<main>
+		<pre id="contents">
+<a href="../">../</a>
+<a href="0.10.0.0/" title="0.10.0.0/">0.10.0.0/</a>                                         2016-05-18 04:44         -      
+<a href="0.10.0.1/" title="0.10.0.1/">0.10.0.1/</a>                                         2016-08-04 12:41         -      
+<a href="0.10.1.0/" title="0.10.1.0/">0.10.1.0/</a>                                         2016-10-14 23:06         -      
+<a href="0.10.1.1/" title="0.10.1.1/">0.10.1.1/</a>                                         2016-12-15 21:12         -      
+<a href="0.10.2.0/" title="0.10.2.0/">0.10.2.0/</a>                                         2017-02-14 17:42         -      
+<a href="0.10.2.1/" title="0.10.2.1/">0.10.2.1/</a>                                         2017-04-21 16:42         -      
+<a href="0.10.2.2/" title="0.10.2.2/">0.10.2.2/</a>                                         2018-06-23 01:13         -      
+<a href="0.11.0.0/" title="0.11.0.0/">0.11.0.0/</a>                                         2017-06-22 22:23         -      
+<a href="0.11.0.1/" title="0.11.0.1/">0.11.0.1/</a>                                         2017-09-05 18:29         -      
+<a href="0.11.0.2/" title="0.11.0.2/">0.11.0.2/</a>                                         2017-11-10 23:56         -      
+<a href="0.11.0.3/" title="0.11.0.3/">0.11.0.3/</a>                                         2018-06-22 21:41         -      
+<a href="0.8.2-beta/" title="0.8.2-beta/">0.8.2-beta/</a>                                       2014-10-21 19:55         -      
+<a href="0.8.2.0/" title="0.8.2.0/">0.8.2.0/</a>                                          2015-01-29 05:08         -      
+<a href="0.8.2.1/" title="0.8.2.1/">0.8.2.1/</a>                                          2015-02-26 22:42         -      
+<a href="0.8.2.2/" title="0.8.2.2/">0.8.2.2/</a>                                          2015-09-03 02:13         -      
+<a href="0.9.0.0/" title="0.9.0.0/">0.9.0.0/</a>                                          2015-11-21 01:12         -      
+<a href="0.9.0.1/" title="0.9.0.1/">0.9.0.1/</a>                                          2016-02-12 02:21         -      
+<a href="1.0.0/" title="1.0.0/">1.0.0/</a>                                            2017-10-27 16:31         -      
+<a href="1.0.1/" title="1.0.1/">1.0.1/</a>                                            2018-03-05 16:51         -      
+<a href="1.0.2/" title="1.0.2/">1.0.2/</a>                                            2018-06-30 04:16         -      
+<a href="1.1.0/" title="1.1.0/">1.1.0/</a>                                            2018-03-23 23:04         -      
+<a href="1.1.1/" title="1.1.1/">1.1.1/</a>                                            2018-07-07 08:26         -      
+<a href="2.0.0/" title="2.0.0/">2.0.0/</a>                                            2018-07-24 14:41         -      
+<a href="2.0.1/" title="2.0.1/">2.0.1/</a>                                            2018-10-25 18:11         -      
+<a href="2.1.0/" title="2.1.0/">2.1.0/</a>                                            2018-11-19 18:26         -      
+<a href="2.1.1/" title="2.1.1/">2.1.1/</a>                                            2019-02-08 19:34         -      
+<a href="2.2.0/" title="2.2.0/">2.2.0/</a>                                            2019-03-09 21:43         -      
+<a href="2.2.1/" title="2.2.1/">2.2.1/</a>                                            2019-05-13 17:12         -      
+<a href="2.2.2/" title="2.2.2/">2.2.2/</a>                                            2019-10-23 06:11         -      
+<a href="2.3.0/" title="2.3.0/">2.3.0/</a>                                            2019-06-19 21:48         -      
+<a href="2.3.1/" title="2.3.1/">2.3.1/</a>                                            2019-10-18 01:09         -      
+<a href="2.4.0/" title="2.4.0/">2.4.0/</a>                                            2019-12-09 16:53         -      
+<a href="2.4.1/" title="2.4.1/">2.4.1/</a>                                            2020-03-03 01:23         -      
+<a href="2.5.0/" title="2.5.0/">2.5.0/</a>                                            2020-04-08 02:20         -      
+<a href="2.5.1/" title="2.5.1/">2.5.1/</a>                                            2020-07-24 02:00         -      
+<a href="2.6.0/" title="2.6.0/">2.6.0/</a>                                            2020-07-28 18:39         -      
+<a href="maven-metadata.xml" title="maven-metadata.xml">maven-metadata.xml</a>                                2020-08-10 15:47      1469      
+<a href="maven-metadata.xml.md5" title="maven-metadata.xml.md5">maven-metadata.xml.md5</a>                            2020-08-10 15:47        32      
+<a href="maven-metadata.xml.sha1" title="maven-metadata.xml.sha1">maven-metadata.xml.sha1</a>                           2020-08-10 15:47        40      
+<a href="maven-metadata.xml.sha256" title="maven-metadata.xml.sha256">maven-metadata.xml.sha256</a>                         2020-08-10 15:47        64      
+<a href="maven-metadata.xml.sha512" title="maven-metadata.xml.sha512">maven-metadata.xml.sha512</a>                         2020-08-10 15:47       128      
+		</pre>
+	</main>
+	<hr/>
+</body>
+
+</html>


### PR DESCRIPTION
#### Infer PURLs
- Remember the combination between GitHub repo <--> Base PURL
- When a new Vulnerability does not have PURLs, try to build them from the archive
- Parse sources of information that DO contain PURLs first to make sure we ca infer **as many as possible** 

#### Non-linear version ranges
- VersionRanger stores a timestamp for each version indicating the release
- Keep the versions sorted by release date