### PR TITLE
Makes the logging format of the producer compatible with our logging & monitoring infrastructure

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -5,10 +5,29 @@
     <timestamp key="byDay" datePattern="yyyyMMdd'T'HHmmss"/>
     <property name="LOG_DIR" value="/mnt/fasten/vuln/producer/logs"/>
 
+    <!--  This format is proposed by Wouter Zorgdrager for monitoring FASTEN services   -->
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>DENY</onMatch>
+            <onMismatch>ACCEPT</onMismatch>
+        </filter>
         <encoder>
-            <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>[%date{ISO8601}] [%-5level] [%thread] [%logger{1}] - %msg%n</pattern>
         </encoder>
+    </appender>
+
+    <!--  This format is proposed by Wouter Zorgdrager for monitoring FASTEN services   -->
+    <appender name="STDOUT-ERROR" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>[%date{ISO8601}] [%-5level] [%thread] [%logger{1}] - %msg%n%xEx{full}%n</pattern>
+        </encoder>
+        <target>System.err</target>
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
@@ -19,8 +38,9 @@
         </encoder>
     </appender>
 
-    <root>
+    <root level="debug">
         <appender-ref ref="STDOUT" />
+        <appender-ref ref="STDOUT-ERROR" />
         <appender-ref ref="FILE"/>
     </root>
 


### PR DESCRIPTION
I have changed the `logback.xml` according to this [format](https://github.com/fasten-project/k8s-deployments/tree/logging/monitoring/logging#format) so that we can see the logs of the producer on Grafana.

@elanzini
Please take a look at the `logback.xml` file and merge the PR if it's okay. Let me know if further changes are required.