### PR TITLE
CPEtoPURL heuristics for Maven and PyPI

### DIFF
--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/PatchFinder.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/PatchFinder.java
@@ -22,6 +22,7 @@ import com.mongodb.client.MongoDatabase;
 import eu.fasten.vulnerabilityproducer.db.NitriteController;
 import eu.fasten.vulnerabilityproducer.db.PatchObject;
 import eu.fasten.vulnerabilityproducer.utils.connections.JavaHttpClient;
+import eu.fasten.vulnerabilityproducer.utils.connections.MongoConnector;
 import eu.fasten.vulnerabilityproducer.utils.patches.*;
 import org.jooq.tools.json.JSONParser;
 import org.slf4j.Logger;

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/Vulnerability.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/Vulnerability.java
@@ -18,6 +18,7 @@
 
 package eu.fasten.vulnerabilityproducer.utils;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 import eu.fasten.vulnerabilityproducer.utils.mappers.Severity;
@@ -120,6 +121,7 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
 
     private String id;
     private List<String> purls;
+    private HashSet<String> baseCpes;
     @SerializedName(value = "first_patched_purls")
     private HashSet<String> firstPatchedPurls;
     private Double scoreCVSS2;
@@ -259,6 +261,15 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
 
     public void setSeverity(Severity severity) {
         this.severity = severity;
+    }
+
+    @JsonIgnore
+    public HashSet<String> getBaseCpes() {
+        return baseCpes;
+    }
+
+    public void setBaseCpes(HashSet<String> baseCpes) {
+        this.baseCpes = baseCpes;
     }
 
     // Extra Setters and Getters for Serializability

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/PurlMapper.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/PurlMapper.java
@@ -172,13 +172,16 @@ public class PurlMapper {
                if (mavenMap.containsKey(repoUrl)) {
                    var basePurl = mavenMap.get(repoUrl);
                    var versions = versionRanger.getCPEVersions(vulnerability.getId()).get(cpe);
-                   versions.forEach(version -> vulnerability.addPurl(basePurl + "@" + version));
+                   if (versions != null) {
+                       versions.forEach(version -> vulnerability.addPurl(basePurl + "@" + version));
+                   }
                }
                if (pypiMap.containsKey(repoUrl)) {
                    var basePurl = pypiMap.get(repoUrl);
                    var versions = versionRanger.getCPEVersions(vulnerability.getId()).get(cpe);
-                   versions.forEach(version -> vulnerability.addPurl(basePurl + "@" + version));
-               }
+                   if (versions != null) {
+                       versions.forEach(version -> vulnerability.addPurl(basePurl + "@" + version));
+                   }               }
            }
         });
 

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/PurlMapper.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/PurlMapper.java
@@ -30,24 +30,25 @@ import org.joda.time.format.DateTimeFormatter;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class PurlMapper {
     VersionRanger versionRanger;
     PatchFinder patchFinder;
     DateTimeFormatter formatter = DateTimeFormat.forPattern("yyyy-MM-dd");
-    // Base Repo URL --> Base PURL
-    public HashMap<String, String> purlMappings;
+    public HashMap<String, String> mavenMap;    // repo_url -> purl
+    public HashMap<String, String> pypiMap;     // repo_url -> purl
+    public HashMap<String, String> cpeMap;      // cpe_base -> repo_url
 
-    public PurlMapper(VersionRanger versionRanger, PatchFinder patchFinder, String pathToReposMaps) {
+    public PurlMapper(VersionRanger versionRanger, PatchFinder patchFinder, String pathToMaps) {
         this.versionRanger = versionRanger;
         this.patchFinder = patchFinder;
-        this.purlMappings = loadReposMapFromMemory(pathToReposMaps);
+        this.mavenMap = loadReposMapFromMemory(pathToMaps + "repo_map_maven.json");
+        this.pypiMap = loadReposMapFromMemory(pathToMaps + "repo_map_pypi.json");
+        this.cpeMap = loadReposMapFromMemory(pathToMaps + "cpe_map_repos.json");
     }
 
-    private HashMap<String, String> loadReposMapFromMemory(String path) {
+    private static HashMap<String, String> loadReposMapFromMemory(String path) {
         var map = new File(path);
         String jsonString = null;
         if (map.exists()) {
@@ -67,13 +68,32 @@ public class PurlMapper {
      */
     public void inferPurls(Vulnerability v) {
         var baseRepo = patchFinder.getBaseRepo(v);
-        if (baseRepo == null)   return;
-        DateTime patchedDate = getPatchDateVulnerability(v);
+        var patchedDate = getPatchDateVulnerability(v);
 
+        findMatchedPurl(mavenMap, v, patchedDate, baseRepo);
+        findMatchedPurl(pypiMap, v, patchedDate, baseRepo);
+
+        if (v.getPurls().size() == 0) {
+            findPurlsFromCpes(v);
+        }
+    }
+
+    /**
+     * Helper method to inject stuff in the purl_maps and infer.
+     * @param purlMap - map of the purls
+     * @param v - Vulnerability Object
+     * @param patchedDate - date of the patch
+     * @param baseRepo - baseRepo extracted from the vulnerability
+     */
+    public void findMatchedPurl(HashMap<String, String> purlMap,
+                                Vulnerability v,
+                                DateTime patchedDate,
+                                String baseRepo) {
         // Try to infer purls if missing
+        if (baseRepo == null)   return;
         if (v.getPurls().size() == 0 && patchedDate != null) {
-            if (purlMappings.get(baseRepo) != null) {
-                var basePurl = purlMappings.get(baseRepo);
+            if (purlMap.get(baseRepo) != null) {
+                var basePurl = purlMap.get(baseRepo);
                 if (basePurl != null) {
                     var inferredPurls = versionRanger.getPurlsBeforeDate(basePurl, patchedDate);
                     inferredPurls.forEach(v::addPurl);
@@ -82,12 +102,12 @@ public class PurlMapper {
         } else {
             // Store purl mappings
             String purlBase = getPurlBase(v);
-            purlMappings.put(baseRepo, purlBase);
+            purlMap.put(baseRepo, purlBase);
         }
 
         // Try to infer firstPatchedVersion if missing
         if (v.getFirstPatchedPurls().size() == 0 && patchedDate != null) {
-            var basePurl = purlMappings.get(baseRepo);
+            var basePurl = purlMap.get(baseRepo);
             if (basePurl != null) {
                 var firstPatchedPurl = versionRanger.getFirstPurlAfterDate(basePurl, patchedDate);
                 if (firstPatchedPurl != null) v.getFirstPatchedPurls().add(firstPatchedPurl);
@@ -138,5 +158,39 @@ public class PurlMapper {
         var base = firstPurl.split("@")[0];
         assert base != null;
         return base;
+    }
+
+    /**
+     * Finds suitable PURLs corresponding to the
+     * @param vulnerability - Vulnerability Object to inject information.
+     */
+    public void findPurlsFromCpes(Vulnerability vulnerability) {
+        var cpes = vulnerability.getBaseCpes();
+        cpes.forEach(cpe -> {
+           if (cpeMap.containsKey(cpe)) {
+               var repoUrl = cpeMap.get(cpe);
+               if (mavenMap.containsKey(repoUrl)) {
+                   var basePurl = mavenMap.get(repoUrl);
+                   var versions = versionRanger.getCPEVersions(vulnerability.getId()).get(cpe);
+                   versions.forEach(version -> vulnerability.addPurl(basePurl + "@" + version));
+               }
+               if (pypiMap.containsKey(repoUrl)) {
+                   var basePurl = pypiMap.get(repoUrl);
+                   var versions = versionRanger.getCPEVersions(vulnerability.getId()).get(cpe);
+                   versions.forEach(version -> vulnerability.addPurl(basePurl + "@" + version));
+               }
+           }
+        });
+
+        if (vulnerability.getPurls().size() == 0) {
+            cpes.forEach(cpe -> {
+               if (cpe.startsWith("cpe:2.3:a:apache:")) {
+                   var project = cpe.substring("cpe:2.3:a:apache:".length());
+                   var basePurl = "pkg:maven/org.apache." + project + "/" + project;
+                   var versions = versionRanger.getCPEVersions(vulnerability.getId()).get(cpe);
+                   versions.forEach(version -> vulnerability.addPurl(basePurl + "@" + version));
+               }
+            });
+        }
     }
 }

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/VersionRanger.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/VersionRanger.java
@@ -42,6 +42,8 @@ public class VersionRanger {
     // DEBIAN encoding: pkg:deb/debian/<package_name>
     public HashMap<String, List<Pair<String, DateTime>>> versionsMappings;
     public Comparator<Pair<String, DateTime>> versionSorter;
+    public String nvdApiUrl = "https://services.nvd.nist.gov/rest/json/cve/1.0/%s?addOns=dictionaryCpes";
+
 
     /**
      * Constructor to inject the client
@@ -580,5 +582,39 @@ public class VersionRanger {
                 injectVersionsDebianPackage(pgk);
             }
         }
+    }
+
+    /**
+     * Uses NVD API to retrieve the entire CPE dictionary for the vulnerability at hand.
+     * Changes the PURLs in place to the versions found.
+     * @param id - CVE-id of the vulnerability
+     * @return map : cpe_base -> vulnerable_versions
+     */
+    public HashMap<String, List<String>> getCPEVersions(String id) {
+        var versions = new HashMap<String, List<String>>();
+        var vulnUrl = String.format(nvdApiUrl, id);
+        try {
+            var data = new JSONObject(client.sendGet(vulnUrl));
+            var results = data.getJSONObject("result");
+            var cves = results.getJSONArray("CVE_Items");
+            var configurations = cves.getJSONObject(0).getJSONObject("configurations");
+            var nodes = configurations.getJSONArray("nodes");
+            nodes.forEach(node -> {
+                    var cpes = ((JSONObject) node).getJSONArray("cpe_match");
+                    cpes.forEach(cpe -> {
+                        var cpe23 = ((JSONObject) cpe).get("cpe23Uri").toString();
+                        var cpe_base = String.join(":", Arrays.copyOfRange(cpe23.split(":"), 0, 5));
+                        var version = cpe23.split(":")[5];
+                        var details = cpe23.split(":")[6];
+                        if (!details.equals("*"))   version = version + "." + details;
+                        if (!versions.containsKey(cpe_base)) {
+                            versions.put(cpe_base, new ArrayList<>());
+                        }
+                        versions.get(cpe_base).add(version);
+                    });
+            });
+        } catch (Exception e) {
+        }
+        return versions;
     }
 }

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/NVDParser.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/NVDParser.java
@@ -183,12 +183,12 @@ public class NVDParser implements VulnerabilityParser {
 
         var cpes = new HashSet<String>();
         cveItem.getConfigurations().getNodes().forEach(node -> {
-            cpes.add(
-                    String.join(":", Arrays.copyOfRange(node.getCpeMatch().get(0).getCpe23Uri().split(":"), 0, 5))
-            );
+            if (node.getCpeMatch().size() > 0) {
+                cpes.add(String.join(":", Arrays.copyOfRange(node.getCpeMatch().get(0).getCpe23Uri().split(":"), 0, 5)));
+            }
         });
-
         vulnerability.setBaseCpes(cpes);
+
         return vulnerability;
     }
 

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/NVDParser.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/NVDParser.java
@@ -18,27 +18,17 @@
 
 package eu.fasten.vulnerabilityproducer.utils.parsers;
 
-import java.io.*;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
-import java.util.zip.GZIPInputStream;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import eu.fasten.vulnerabilityproducer.utils.Vulnerability;
 import eu.fasten.vulnerabilityproducer.utils.connections.JavaHttpClient;
+import eu.fasten.vulnerabilityproducer.utils.mappers.PurlMapper;
 import eu.fasten.vulnerabilityproducer.utils.mappers.Severity;
-import org.joda.time.DateTime;
+import org.apache.commons.io.FileUtils;
 import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 import org.jooq.tools.json.JSONParser;
 import org.owasp.dependencycheck.data.nvd.json.DefCveItem;
@@ -47,6 +37,14 @@ import org.owasp.dependencycheck.utils.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.*;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPInputStream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -56,12 +54,21 @@ public class NVDParser implements VulnerabilityParser {
     public static JavaHttpClient client;
     public static Downloader downloader;
     public static String mnt;
+    public static PurlMapper purlMapper;
     private final Logger logger = LoggerFactory.getLogger(NVDParser.class.getName());
 
-    public NVDParser(JSONParser jsonParser, JavaHttpClient client, String mnt) {
+//    private final Function<List<DefCpeMatch>, List<String>> getApachePurls = cpes -> {
+//        return cpes.stream().map(cpe -> {
+//            var product = cpe.getCpe23Uri().split();
+//            var version = "";
+//        }).collect(Collectors.toList());
+//    };
+
+    public NVDParser(JSONParser jsonParser, JavaHttpClient client, PurlMapper purlMapper, String mnt) {
         this.mnt = mnt;
         this.client = client;
         this.jsonParser = jsonParser;
+        this.purlMapper = purlMapper;
     }
 
     /**
@@ -132,8 +139,8 @@ public class NVDParser implements VulnerabilityParser {
             TooManyRequestsException,
             DownloadFailedException,
             ResourceNotFoundException {
-        URL updates_url = new URL("https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz");
-        File out_path = new File(mnt + "/nvd/nvdcve-1.1-modified.json.gz");
+        var updates_url = new URL("https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz");
+        var out_path = new File(mnt + "/nvd/nvdcve-1.1-modified.json.gz");
         downloader.fetchFile(updates_url, out_path);
         return out_path;
     }
@@ -145,9 +152,9 @@ public class NVDParser implements VulnerabilityParser {
      * @return the parsed and enriched vulnerability
      */
     public Vulnerability parseVulnerability(DefCveItem cveItem) {
-        Vulnerability vulnerability = new Vulnerability(cveItem.getCve().getCVEDataMeta().getId());
+        var vulnerability = new Vulnerability(cveItem.getCve().getCVEDataMeta().getId());
         logger.info("Parsing Vulnerability with ID - " + vulnerability.getId());
-        DateTimeFormatter df = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mmZ");
+        var df = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mmZ");
 
         vulnerability.setDescription(cveItem.getCve().getDescription().getDescriptionData().get(0).getValue());
         if (cveItem.getImpact().getBaseMetricV2() != null) {
@@ -158,8 +165,8 @@ public class NVDParser implements VulnerabilityParser {
             vulnerability.setScoreCVSS3(cveItem.getImpact().getBaseMetricV3().getCvssV3().getBaseScore());
         }
 
-        DateTime pdt = df.parseDateTime(cveItem.getPublishedDate());
-        DateTime ldt = df.parseDateTime(cveItem.getLastModifiedDate());
+        var pdt = df.parseDateTime(cveItem.getPublishedDate());
+        var ldt = df.parseDateTime(cveItem.getLastModifiedDate());
         vulnerability.setPublishedDate(pdt.toString(ISODateTimeFormat.date()));
         vulnerability.setLastModifiedDate(ldt.toString(ISODateTimeFormat.date()));
 
@@ -174,6 +181,14 @@ public class NVDParser implements VulnerabilityParser {
             }
         }
 
+        var cpes = new HashSet<String>();
+        cveItem.getConfigurations().getNodes().forEach(node -> {
+            cpes.add(
+                    String.join(":", Arrays.copyOfRange(node.getCpeMatch().get(0).getCpe23Uri().split(":"), 0, 5))
+            );
+        });
+
+        vulnerability.setBaseCpes(cpes);
         return vulnerability;
     }
 

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
@@ -69,9 +69,9 @@ public class ParserManager {
         this.extraParser = new ExtraParser(client, versionRanger, mnt);
         this.ovalParser = new OVALParser(client, versionRanger);
         this.ghParser = new GHParser(client, ghToken, versionRanger, mnt + "/trackers/ghcursor.txt");
-        this.nvdParser = new NVDParser(new JSONParser(), client, mnt);
         this.patchFinder = new PatchFinder(mongoDatabase, client, ghToken);
-        this.purlMapper = new PurlMapper(versionRanger, patchFinder, mnt + "/datasets/repo_coordinates.json");
+        this.purlMapper = new PurlMapper(versionRanger, patchFinder, mnt + "/datasets/purl_maps/");
+        this.nvdParser = new NVDParser(new JSONParser(), client, this.purlMapper, mnt);
     }
 
     /**
@@ -231,11 +231,13 @@ public class ParserManager {
                               GHParser ghParser,
                               ExtraParser extraParser,
                               OVALParser ovalParser,
-                              PatchFinder patchFinder) {
+                              PatchFinder patchFinder,
+                              PurlMapper purlMapper) {
         this.nvdParser = nvdParser;
         this.ghParser = ghParser;
         this.extraParser = extraParser;
         this.ovalParser = ovalParser;
         this.patchFinder = patchFinder;
+        this.purlMapper = purlMapper;
     }
 }

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
@@ -70,7 +70,7 @@ public class ParserManager {
         this.ovalParser = new OVALParser(client, versionRanger);
         this.ghParser = new GHParser(client, ghToken, versionRanger, mnt + "/trackers/ghcursor.txt");
         this.patchFinder = new PatchFinder(mongoDatabase, client, ghToken);
-        this.purlMapper = new PurlMapper(versionRanger, patchFinder, mnt + "/datasets/purl_maps/");
+        this.purlMapper = new PurlMapper(versionRanger, patchFinder, "./src/main/resources/datasets/purl_maps/");
         this.nvdParser = new NVDParser(new JSONParser(), client, this.purlMapper, mnt);
     }
 
@@ -90,7 +90,6 @@ public class ParserManager {
         var mapFromOVAL = ovalParser.getVulnerabilities();
 
         logger.info("Merging all the pulled vulnerabilities");
-        // Put all maps from parsers into a list to pass it on
         List<HashMap<String, Vulnerability>> maps = new ArrayList<>();
         maps.add(mapFromNVD);
         maps.add(mapFromExtraSources);
@@ -104,13 +103,8 @@ public class ParserManager {
             while (!vulnerabilities.isEmpty()) {
                 var v = vulnerabilities.poll();
                 logger.info("Looking for patches in references of " + v.getId());
-                // Adding patch information
                 patchFinder.parseReferences(v, nitriteController);
-                // Infer purls
                 purlMapper.inferPurls(v);
-                // Store statement
-                // storeVulnJson(v);
-                // Publish to kafka if new
                 if (!isDuplicate(v)) {
                     logger.info("Publishing " + v.getId() + " to Kafka");
                     kafkaProducer.send(new ProducerRecord<>(topic, v.toJson()));

--- a/src/test/java/eu/fasten/vulnerabilityproducer/mappers/PurlMapperTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/mappers/PurlMapperTest.java
@@ -27,10 +27,7 @@ import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -41,7 +38,7 @@ public class PurlMapperTest {
 
     VersionRanger vrMock = Mockito.mock(VersionRanger.class);
     PatchFinder pfMock = Mockito.mock(PatchFinder.class);
-    PurlMapper purlMapper = new PurlMapper(vrMock, pfMock, "./src/test/resources/repo_coordinates.json");
+    PurlMapper purlMapper = new PurlMapper(vrMock, pfMock, "./src/test/resources/purl_maps/");
 
     @Test
     public void getBasePurlTest() {
@@ -62,12 +59,12 @@ public class PurlMapperTest {
         when(pfMock.getBaseRepo(v)).thenReturn("https://github.com/python/django");
 
         purlMapper.inferPurls(v);
-        assertEquals("pkg:pypi/django", purlMapper.purlMappings.get("https://github.com/python/django"));
+        assertEquals("pkg:pypi/django", purlMapper.pypiMap.get("https://github.com/python/django"));
     }
 
     @Test
     public void inferPurlMissing() {
-        purlMapper.purlMappings.put("https://github.com/python/django", "pkg:pypi/django");
+        purlMapper.pypiMap.put("https://github.com/python/django", "pkg:pypi/django");
         var versions = new ArrayList<String>(); versions.add("pkg:pypi/django@1.9");
         Vulnerability v = new Vulnerability();
         v.addPatchLink("https//github.com/python/django/commit/5326bi6b5u53b1u5ob1b5i265");
@@ -78,5 +75,32 @@ public class PurlMapperTest {
 
         purlMapper.inferPurls(v);
         assertTrue(v.getPurls().contains("pkg:pypi/django@1.9"));
+    }
+
+    @Test
+    public void inferPurlFromCpes() {
+        var v = new Vulnerability("TEST-1");
+        v.setBaseCpes(new HashSet<>(Collections.singletonList("cpe:2.3:a:google:guava")));
+
+        var cpe_versions = new HashMap<String, List<String>>();
+        cpe_versions.put("cpe:2.3:a:google:guava",  Arrays.asList("1.0", "2.0"));
+        when(vrMock.getCPEVersions(v.getId())).thenReturn(cpe_versions);
+
+        purlMapper.inferPurls(v);
+        assertTrue(v.getPurls().contains("pkg:maven/org.google.guava/guava@1.0"));
+        assertTrue(v.getPurls().contains("pkg:maven/org.google.guava/guava@2.0"));
+    }
+
+    @Test
+    public void testSpecialApacheCase() {
+        var v = new Vulnerability("TEST-1");
+        v.setBaseCpes(new HashSet<>(Collections.singletonList("cpe:2.3:a:apache:tomcat")));
+
+        var cpe_versions = new HashMap<String, List<String>>();
+        cpe_versions.put("cpe:2.3:a:apache:tomcat",  Arrays.asList("10.0"));
+        when(vrMock.getCPEVersions(v.getId())).thenReturn(cpe_versions);
+
+        purlMapper.inferPurls(v);
+        assertTrue(v.getPurls().contains("pkg:maven/org.apache.tomcat/tomcat@10.0"));
     }
 }

--- a/src/test/java/eu/fasten/vulnerabilityproducer/mappers/VersionRangerTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/mappers/VersionRangerTest.java
@@ -100,6 +100,17 @@ public class VersionRangerTest {
         }
     }
 
+    String nvdResponse;
+    {
+        try {
+            nvdResponse = FileUtils.readFileToString(
+                    new File("./src/test/resources/version_handling/nvd_with_cpe.json"),
+                    StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
     @BeforeEach
     public void setup() {
 
@@ -327,5 +338,15 @@ public class VersionRangerTest {
                 "pkg:gem/t@0.3.0", "pkg:gem/t@0.3.1", "pkg:gem/t@0.4.0");
 
         assertEquals(vvThreeExp, vvThree);
+    }
+
+    @Test
+    public void testGetCPEVersions() {
+        var nvdUrl = "https://services.nvd.nist.gov/rest/json/cve/1.0/CVE-2019-10247?addOns=dictionaryCpes";
+        when(clientMock.sendGet(nvdUrl)).thenReturn(nvdResponse);
+
+        var versions = vr.getCPEVersions("CVE-2019-10247");
+        assertTrue(versions.get("cpe:2.3:a:eclipse:jetty").contains("7.0.0.maintenance_2"));
+        assertTrue(versions.get("cpe:2.3:a:eclipse:jetty").contains("7.0.0.maintenance_1"));
     }
 }

--- a/src/test/java/eu/fasten/vulnerabilityproducer/parsers/NVDParserTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/parsers/NVDParserTest.java
@@ -20,6 +20,7 @@ package eu.fasten.vulnerabilityproducer.parsers;
 
 import eu.fasten.vulnerabilityproducer.VulnerabilityProducerTest;
 import eu.fasten.vulnerabilityproducer.utils.connections.JavaHttpClient;
+import eu.fasten.vulnerabilityproducer.utils.mappers.PurlMapper;
 import eu.fasten.vulnerabilityproducer.utils.parsers.NVDParser;
 import eu.fasten.vulnerabilityproducer.utils.Vulnerability;
 import org.jooq.tools.json.JSONParser;
@@ -39,12 +40,13 @@ public class NVDParserTest {
 
     // Inject Java Http Client to test
     JavaHttpClient clientMock = Mockito.mock(JavaHttpClient.class);
+    PurlMapper purlMapperMock = Mockito.mock(PurlMapper.class);
 
     private NVDParser parser;
 
     @BeforeEach
     public void setup() {
-        parser = new NVDParser(new JSONParser(), clientMock, VulnerabilityProducerTest.testmnt);
+        parser = new NVDParser(new JSONParser(), clientMock, purlMapperMock, VulnerabilityProducerTest.testmnt);
     }
 
     @Test

--- a/src/test/java/eu/fasten/vulnerabilityproducer/parsers/ParserManagerTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/parsers/ParserManagerTest.java
@@ -24,6 +24,7 @@ import eu.fasten.vulnerabilityproducer.db.NitriteController;
 import eu.fasten.vulnerabilityproducer.utils.PatchFinder;
 import eu.fasten.vulnerabilityproducer.utils.Vulnerability;
 import eu.fasten.vulnerabilityproducer.utils.connections.JavaHttpClient;
+import eu.fasten.vulnerabilityproducer.utils.mappers.PurlMapper;
 import eu.fasten.vulnerabilityproducer.utils.mappers.Severity;
 import eu.fasten.vulnerabilityproducer.utils.parsers.*;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -35,8 +36,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class ParserManagerTest {
 
@@ -51,6 +51,7 @@ public class ParserManagerTest {
     OVALParser ovalParserMock = Mockito.mock(OVALParser.class);
     ExtraParser extraParserMock = Mockito.mock(ExtraParser.class);
     PatchFinder patchFinderMock = Mockito.mock(PatchFinder.class);
+    PurlMapper purlMapperMock = Mockito.mock(PurlMapper.class);
 
     @Test
     public void testGetDataAndMergeFromParsers() {
@@ -59,7 +60,8 @@ public class ParserManagerTest {
                 ghParserMock,
                 extraParserMock,
                 ovalParserMock,
-                patchFinderMock);
+                patchFinderMock,
+                purlMapperMock);
 
         HashMap<String, Vulnerability> nvdVulns = new HashMap<>();
         Vulnerability v1 = new Vulnerability("CVE-TEST-1");
@@ -104,6 +106,7 @@ public class ParserManagerTest {
         when(ghParserMock.getVulnerabilities()).thenReturn(ghVulns);
         when(extraParserMock.getVulnerabilities()).thenReturn(extraVulns);
         when(ovalParserMock.getVulnerabilities()).thenReturn(ovalVulns);
+        doNothing().when(purlMapperMock).inferPurls(Mockito.any());
 
         pm.getVulnerabilitiesFromParsers(kpMock, topic);
 
@@ -142,7 +145,8 @@ public class ParserManagerTest {
                 ghParserMock,
                 extraParserMock,
                 ovalParserMock,
-                patchFinderMock);
+                patchFinderMock,
+                purlMapperMock);
 
         HashMap<String, Vulnerability> nvdVulns = new HashMap<>();
         var v1 = new Vulnerability("CVE-TEST-1");
@@ -159,6 +163,7 @@ public class ParserManagerTest {
         when(nvdParserMock.getUpdates()).thenReturn(nvdVulns);
         when(ghParserMock.getUpdates()).thenReturn(ghVulns);
         when(ovalParserMock.getUpdates()).thenReturn(ovalVulns);
+        doNothing().when(purlMapperMock).inferPurls(Mockito.any());
 
         pm.getUpdatesFromParsers(kpMock, topic);
 

--- a/src/test/resources/purl_maps/cpe_map_repos.json
+++ b/src/test/resources/purl_maps/cpe_map_repos.json
@@ -1,0 +1,4 @@
+{
+  "cpe:2.3:a:pyyaml:pyyaml": "https://github.com/yaml/pyyaml",
+  "cpe:2.3:a:google:guava": "https://github.com/google/guava"
+}

--- a/src/test/resources/purl_maps/repo_map_maven.json
+++ b/src/test/resources/purl_maps/repo_map_maven.json
@@ -1,0 +1,3 @@
+{
+  "https://github.com/google/guava" : "pkg:maven/org.google.guava/guava"
+}

--- a/src/test/resources/purl_maps/repo_map_pypi.json
+++ b/src/test/resources/purl_maps/repo_map_pypi.json
@@ -1,0 +1,3 @@
+{
+  "https://github.com/pyyaml/pyyaml" : "pkg:pypi/pyyaml"
+}

--- a/src/test/resources/version_handling/nvd_with_cpe.json
+++ b/src/test/resources/version_handling/nvd_with_cpe.json
@@ -1,0 +1,201 @@
+{
+  "resultsPerPage": 1,
+  "startIndex": 0,
+  "totalResults": 1,
+  "result": {
+    "CVE_data_type": "CVE",
+    "CVE_data_format": "MITRE",
+    "CVE_data_version": "4.0",
+    "CVE_data_timestamp": "2021-02-03T18:49Z",
+    "CVE_Items": [
+      {
+        "cve": {
+          "data_type": "CVE",
+          "data_format": "MITRE",
+          "data_version": "4.0",
+          "CVE_data_meta": {
+            "ID": "CVE-2019-10247",
+            "ASSIGNER": "cve@mitre.org"
+          },
+          "problemtype": {
+            "problemtype_data": [
+              {
+                "description": [
+                  {
+                    "lang": "en",
+                    "value": "CWE-200"
+                  },
+                  {
+                    "lang": "en",
+                    "value": "CWE-213"
+                  }
+                ]
+              }
+            ]
+          },
+          "references": {
+            "reference_data": [
+              {
+                "url": "https://bugs.eclipse.org/bugs/show_bug.cgi?id=546577",
+                "name": "https://bugs.eclipse.org/bugs/show_bug.cgi?id=546577",
+                "refsource": "CONFIRM",
+                "tags": [
+                  "Vendor Advisory"
+                ]
+              },
+              {
+                "url": "https://security.netapp.com/advisory/ntap-20190509-0003/",
+                "name": "https://security.netapp.com/advisory/ntap-20190509-0003/",
+                "refsource": "CONFIRM",
+                "tags": [
+                  "Third Party Advisory"
+                ]
+              },
+              {
+                "url": "https://lists.apache.org/thread.html/ac51944aef91dd5006b8510b0bef337adaccfe962fb90e7af9c22db4@%3Cissues.activemq.apache.org%3E",
+                "name": "[activemq-issues] 20190723 [jira] [Created] (AMQ-7249) Security Vulnerabilities in the ActiveMQ dependent jars.",
+                "refsource": "MLIST"
+              },
+              {
+                "url": "https://lists.apache.org/thread.html/053d9ce4d579b02203db18545fee5e33f35f2932885459b74d1e4272@%3Cissues.activemq.apache.org%3E",
+                "name": "[activemq-issues] 20190820 [jira] [Created] (AMQ-7279) Security Vulnerabilities in Libraries - jackson-databind-2.9.8.jar, tomcat-servlet-api-8.0.53.jar, tomcat-websocket-api-8.0.53.jar, zookeeper-3.4.6.jar, guava-18.0.jar, jetty-all-9.2.26.v20180806.jar, scala-library-2.11.0.jar",
+                "refsource": "MLIST"
+              },
+              {
+                "url": "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "name": "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "refsource": "MISC"
+              },
+              {
+                "url": "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E",
+                "name": "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "refsource": "MLIST"
+              },
+              {
+                "url": "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E",
+                "name": "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "refsource": "MLIST"
+              },
+              {
+                "url": "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E",
+                "name": "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "refsource": "MLIST"
+              },
+              {
+                "url": "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "name": "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "refsource": "MISC"
+              },
+              {
+                "url": "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E",
+                "name": "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "refsource": "MLIST"
+              },
+              {
+                "url": "https://www.oracle.com/security-alerts/cpuapr2020.html",
+                "name": "N/A",
+                "refsource": "N/A"
+              },
+              {
+                "url": "https://www.oracle.com/security-alerts/cpujul2020.html",
+                "name": "https://www.oracle.com/security-alerts/cpujul2020.html",
+                "refsource": "MISC"
+              },
+              {
+                "url": "https://www.oracle.com/security-alerts/cpuoct2020.html",
+                "name": "https://www.oracle.com/security-alerts/cpuoct2020.html",
+                "refsource": "MISC"
+              },
+              {
+                "url": "https://www.oracle.com/security-alerts/cpujan2021.html",
+                "name": "https://www.oracle.com/security-alerts/cpujan2021.html",
+                "refsource": "MISC"
+              }
+            ]
+          },
+          "description": {
+            "description_data": [
+              {
+                "lang": "en",
+                "value": "In Eclipse Jetty version 7.x, 8.x, 9.2.27 and older, 9.3.26 and older, and 9.4.16 and older, the server running on any OS and Jetty version combination will reveal the configured fully qualified directory base resource location on the output of the 404 error for not finding a Context that matches the requested path. The default server behavior on jetty-distribution and jetty-home will include at the end of the Handler tree a DefaultHandler, which is responsible for reporting this 404 error, it presents the various configured contexts as HTML for users to click through to. This produced HTML includes output that contains the configured fully qualified directory base resource location for each context."
+              }
+            ]
+          }
+        },
+        "configurations": {
+          "CVE_data_version": "4.0",
+          "nodes": [
+            {
+              "operator": "OR",
+              "cpe_match": [
+                {
+                  "vulnerable": true,
+                  "cpe23Uri": "cpe:2.3:a:eclipse:jetty:7.0.0:maintenance_1:*:*:*:*:*:*",
+                  "cpe_name": [
+                    {
+                      "cpe23Uri": "cpe:2.3:a:eclipse:jetty:7.0.0:maintenance_1:*:*:*:*:*:*",
+                      "lastModifiedDate": "2018-08-21T15:16Z"
+                    }
+                  ]
+                },
+                {
+                  "vulnerable": true,
+                  "cpe23Uri": "cpe:2.3:a:eclipse:jetty:7.0.0:maintenance_2:*:*:*:*:*:*",
+                  "cpe_name": [
+                    {
+                      "cpe23Uri": "cpe:2.3:a:eclipse:jetty:7.0.0:maintenance_2:*:*:*:*:*:*",
+                      "lastModifiedDate": "2018-08-21T15:16Z"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "impact": {
+          "baseMetricV3": {
+            "cvssV3": {
+              "version": "3.0",
+              "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+              "attackVector": "NETWORK",
+              "attackComplexity": "LOW",
+              "privilegesRequired": "NONE",
+              "userInteraction": "NONE",
+              "scope": "UNCHANGED",
+              "confidentialityImpact": "LOW",
+              "integrityImpact": "NONE",
+              "availabilityImpact": "NONE",
+              "baseScore": 5.3,
+              "baseSeverity": "MEDIUM"
+            },
+            "exploitabilityScore": 3.9,
+            "impactScore": 1.4
+          },
+          "baseMetricV2": {
+            "cvssV2": {
+              "version": "2.0",
+              "vectorString": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+              "accessVector": "NETWORK",
+              "accessComplexity": "LOW",
+              "authentication": "NONE",
+              "confidentialityImpact": "PARTIAL",
+              "integrityImpact": "NONE",
+              "availabilityImpact": "NONE",
+              "baseScore": 5
+            },
+            "severity": "MEDIUM",
+            "exploitabilityScore": 10,
+            "impactScore": 2.9,
+            "acInsufInfo": false,
+            "obtainAllPrivilege": false,
+            "obtainUserPrivilege": false,
+            "obtainOtherPrivilege": false,
+            "userInteractionRequired": false
+          }
+        },
+        "publishedDate": "2019-04-22T20:29Z",
+        "lastModifiedDate": "2021-01-20T15:15Z"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The `PurlMapper` class handles the logic of this component. There are 3 maps kept cached that support the process:
1. `mavenMap` : `repo_url -> purl` - extracted from pom.xml of entire Maven ecosystem
2. `pypiMap` : `repo_url -> purl` - extracted from PyPI json API of entire PyPI ecosystem
3. `cpeMap`: `cpe_base -> repo_url` - extracted from NVD CPE dictionary

This allows us to guess in two cases:
1. We know the `base_repo` of the vulnerability and we can find it in the maps
2. We know the CPEs of the vulnerability and we can find an intersection between `cpeMap & (pypiMap | mavenMap)`

A special treatment is given to the `apache` projects, which are heuristically assumed to follow this rule of thumb:
`org.apache.<project>:<project>`.