### PR TITLE
Refactor Parsers + Patch Object

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>me.tongfei</groupId>
             <artifactId>progressbar</artifactId>
-            <version>0.9.0</version>
+            <version>0.9.1</version>
         </dependency>
         <!--        END HERE      -->
     </dependencies>

--- a/src/main/java/eu/fasten/vulnerabilityproducer/db/PatchObject.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/db/PatchObject.java
@@ -19,6 +19,7 @@
 package eu.fasten.vulnerabilityproducer.db;
 
 import eu.fasten.vulnerabilityproducer.utils.Vulnerability;
+import eu.fasten.vulnerabilityproducer.utils.Vulnerability.*;
 import org.dizitart.no2.IndexType;
 import org.dizitart.no2.objects.Id;
 import org.dizitart.no2.objects.Index;
@@ -38,9 +39,14 @@ import java.util.Objects;
 public class PatchObject implements Serializable {
     @Id
     String patchURL;
-    HashSet<Vulnerability.Patch> filesChanged;
+    HashSet<Patch> filesChanged;
 
     public PatchObject() {
+    }
+
+    public PatchObject(String patchURL, HashSet<Patch> filesChanged) {
+        this.patchURL = patchURL;
+        this.filesChanged = filesChanged;
     }
 
     public String getPatchURL() {

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/PatchFinder.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/PatchFinder.java
@@ -119,15 +119,13 @@ public class PatchFinder {
      * @param vulnerability to parse references and inject info.
      */
     public void parseReferences(Vulnerability vulnerability, NitriteController nc) {
-        // Parse all patches and references, scouting for diffs
-        var links = vulnerability.getReferences();
-        links.addAll(vulnerability.getPatchLinks());
+        vulnerability.getReferences().addAll(vulnerability.getPatchLinks());    // moving patch_links to refs
+        var links = vulnerability.getReferences();                              // processing all refs
 
         var patchLinks = new HashSet<String>();
         for (String ref : links) {
-            // First look into Nitrite if the ref was already parsed before
             var queryFromNC = nc.findPatchEntry(ref);
-            if (!queryFromNC.isEmpty()) {
+            if (queryFromNC.isPresent()) {
                 var count = new AtomicInteger();
                 queryFromNC.get().forEach(vp -> {
                     vulnerability.addPatch(vp);
@@ -138,28 +136,20 @@ public class PatchFinder {
                         + " patched files in ref: " + ref + " for vulnerability " + vulnerability.getId());
             } else {
                 var vp = parseReference(ref);
-
-                // If something was found, store it in Nitrite and put in it in the Vulnerability
                 if (vp != null && vp.size() > 0) {
-                    // Store it in Nitrite
-                    var po = new PatchObject();
-                    po.setPatchURL(ref);
-                    po.setFilesChanged(vp);
-                    nc.insertPatch(po);
+                    var po = new PatchObject(ref, vp); nc.insertPatch(po);
                     logger.info("Found " + vp.size() + " patched files in ref: " + ref +
                             " for vulnerability " + vulnerability.getId());
-
-                    // Adding patches to the vulnerability
                     vp.forEach(p -> {
+                        if (p.getPatchUrl() != null) patchLinks.add(p.getPatchUrl());
                         vulnerability.addPatch(p);
-                        patchLinks.add(ref);
                     });
                 }
             }
         }
-        // Move the patch links from the refs
-        vulnerability.getReferences().removeAll(patchLinks);
-        vulnerability.setPatchLinks(patchLinks);
+
+        vulnerability.getReferences().removeAll(patchLinks);    // removing patch_links form refs
+        vulnerability.setPatchLinks(patchLinks);                // setting patch_links in vuln_obj
     }
 
     /**

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/Vulnerability.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/Vulnerability.java
@@ -34,6 +34,7 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
         private String patchDate;
         @SerializedName(value = "line_numbers")
         private List<Integer> lineNumbers;
+        private String patchUrl;
 
 
         /**
@@ -43,9 +44,10 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
             this.lineNumbers = new ArrayList<>();
         }
 
-        public Patch(String fileName, List<Integer> lineNumbers) {
+        public Patch(String fileName, List<Integer> lineNumbers, String patchUrl) {
             this.fileName = fileName;
             this.lineNumbers = lineNumbers;
+            this.patchUrl = patchUrl;
         }
 
         /**
@@ -64,6 +66,13 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
             this.fileName = fileName;
             this.patchDate = patchDate;
             this.lineNumbers = lineNumbers;
+        }
+
+        public Patch(String fileName, String patchDate, List<Integer> lineNumbers, String patchUrl) {
+            this.fileName = fileName;
+            this.patchDate = patchDate;
+            this.lineNumbers = lineNumbers;
+            this.patchUrl = patchUrl;
         }
 
         public String getFileName() {
@@ -92,6 +101,14 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
 
         public void setPatchDate(String patchDate) {
             this.patchDate = patchDate;
+        }
+
+        public String getPatchUrl() {
+            return patchUrl;
+        }
+
+        public void setPatchUrl(String patchUrl) {
+            this.patchUrl = patchUrl;
         }
 
         @Override

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/PurlMapper.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/PurlMapper.java
@@ -42,24 +42,23 @@ public class PurlMapper {
 
     public PurlMapper(VersionRanger versionRanger, PatchFinder patchFinder, String pathToMaps) {
         this.versionRanger = versionRanger;
-        this.patchFinder = patchFinder;
-        this.mavenMap = loadReposMapFromMemory(pathToMaps + "repo_map_maven.json");
-        this.pypiMap = loadReposMapFromMemory(pathToMaps + "repo_map_pypi.json");
-        this.cpeMap = loadReposMapFromMemory(pathToMaps + "cpe_map_repos.json");
+        this.patchFinder   = patchFinder;
+        this.mavenMap      = loadReposMapFromMemory(pathToMaps + "repo_map_maven.json");
+        this.pypiMap       = loadReposMapFromMemory(pathToMaps + "repo_map_pypi.json");
+        this.cpeMap        = loadReposMapFromMemory(pathToMaps + "cpe_map_repos.json");
     }
 
     private static HashMap<String, String> loadReposMapFromMemory(String path) {
         var map = new File(path);
-        String jsonString = null;
         if (map.exists()) {
             try {
-                jsonString = FileUtils.readFileToString(map, StandardCharsets.UTF_8);
+                var jsonString = FileUtils.readFileToString(map, StandardCharsets.UTF_8);
+                return new Gson().fromJson(jsonString, new TypeToken<HashMap<String, String>>() {}.getType());
             } catch (IOException e) {
                 e.printStackTrace();
             }
         }
-
-        return new Gson().fromJson(jsonString, new TypeToken<HashMap<String, String>>() {}.getType());
+        return new HashMap<>();
     }
 
     /**
@@ -101,8 +100,7 @@ public class PurlMapper {
             }
         } else {
             // Store purl mappings
-            String purlBase = getPurlBase(v);
-            purlMap.put(baseRepo, purlBase);
+            purlMap.put(baseRepo, getPurlBase(v));
         }
 
         // Try to infer firstPatchedVersion if missing

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
@@ -92,7 +92,7 @@ public class ParserManager {
         var mapFromOVAL = ovalParser.getVulnerabilities();
 
         logger.info("Merging all the pulled vulnerabilities");
-        List<HashMap<String, Vulnerability>> maps = new ArrayList<>();
+        var maps = new ArrayList<HashMap<String, Vulnerability>>();
         maps.add(mapFromNVD);
         maps.add(mapFromExtraSources);
         maps.add(mapFromGH);
@@ -105,12 +105,8 @@ public class ParserManager {
             while (!vulnerabilities.isEmpty()) {
                 var v = vulnerabilities.poll();
                 logger.info("Looking for patches in references of " + v.getId());
-                try {
-                    patchFinder.parseReferences(v, nitriteController);
-                    purlMapper.inferPurls(v);
-                } catch (Exception e) {
-                    logger.info("Something went wrong when processing extra info of " + v.getId());
-                }
+                patchFinder.parseReferences(v, nitriteController);
+                purlMapper.inferPurls(v);
                 if (!isDuplicate(v)) {
                     logger.info("Publishing " + v.getId() + " to Kafka");
                     kafkaProducer.send(new ProducerRecord<>(topic, v.toJson()));

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
@@ -33,10 +33,12 @@ import org.jooq.tools.json.JSONParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
+import java.nio.charset.*;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.*;
+import java.util.stream.*;
 
 /**
  * The responsibility of the ParserManager is to gather Vulnerabilities from all the parsers.

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/BitBucketRanger.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/BitBucketRanger.java
@@ -59,6 +59,7 @@ public class BitBucketRanger {
     public HashSet<Patch> parseBitBucketCommit(String ref) {
         logger.info("Parsing BitBucket commit with URL: " + ref);
         var commitInfo = ref.split("/");
+        var base       = commitInfo[2];
         var project    = commitInfo[3];
         var repo       = commitInfo[4];
         var commitId   = commitInfo[6];
@@ -71,10 +72,11 @@ public class BitBucketRanger {
             var date      = new DateTime(commitObj.get("date").toString()).toString(ISODateTimeFormat.date());
             var diffLink  = patchLink.replace("/commit/", "/diff/");
             var rawDiff   = client.sendGet(diffLink);
+            var vcsPatch  = "git://" + base + "/" + project + "/" + repo + "@" + commitId;
             patches = DiffParser.getPatchesFromDiffs(rawDiff);
             patches.forEach(p -> {
                 p.setPatchDate(date);
-                p.setPatchUrl(ref);
+                p.setPatchUrl(vcsPatch);
             });
         } catch (Exception e) {
             logger.error("Could not parse BitBucketCommit: " + ref);

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/BitBucketRanger.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/BitBucketRanger.java
@@ -20,6 +20,7 @@ package eu.fasten.vulnerabilityproducer.utils.patches;
 
 import eu.fasten.vulnerabilityproducer.utils.PatchFinder;
 import eu.fasten.vulnerabilityproducer.utils.Vulnerability;
+import eu.fasten.vulnerabilityproducer.utils.Vulnerability.*;
 import eu.fasten.vulnerabilityproducer.utils.connections.JavaHttpClient;
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
@@ -41,8 +42,8 @@ import java.util.stream.Collectors;
 
 public class BitBucketRanger {
     private final Logger logger = LoggerFactory.getLogger(BitBucketRanger.class.getName());
-    JSONParser jsonParser;
-    JavaHttpClient client;
+    private JSONParser jsonParser;
+    private JavaHttpClient client;
 
     public BitBucketRanger(JavaHttpClient client, JSONParser jsonParser) {
         this.jsonParser = jsonParser;
@@ -55,35 +56,30 @@ public class BitBucketRanger {
      * @param ref - link to a Bitbucket commit
      * @return - set of patches
      */
-    public HashSet<Vulnerability.Patch> parseBitBucketCommit(String ref) {
+    public HashSet<Patch> parseBitBucketCommit(String ref) {
         logger.info("Parsing BitBucket commit with URL: " + ref);
         var commitInfo = ref.split("/");
-        var project = commitInfo[3];
-        var repo = commitInfo[4];
-        var commitId = commitInfo[6];
-        ref = "https://bitbucket.org/api/2.0/repositories/" + project + "/" + repo + "/commit/" + commitId;
-        var commitJson = client.sendGet(ref);
-        if (!commitJson.equals(" ") && !commitJson.contains("\"message\": \"Commit not found\",")) {
-            JSONObject commitObj = null;
-            try {
-                commitObj = (JSONObject) jsonParser.parse(commitJson);
-            } catch (ParseException e) {
-                e.printStackTrace();
-            }
-            var date = new DateTime(commitObj.get("date").toString()).toString(ISODateTimeFormat.date());
-            var diffLink = ref.replace("/commit/", "/diff/");
-            var rawDiff = client.sendGet(diffLink);
-            HashSet<Vulnerability.Patch> diffPatches = null;
-            try {
-                diffPatches = DiffParser.getPatchesFromDiffs(rawDiff);
-            } catch (Exception e) {
-                logger.error("Could not extract diffs from ref: " + ref);
-                return null;
-            }
-            diffPatches.stream().forEach(x -> x.setPatchDate(date));
-            return diffPatches;
+        var project    = commitInfo[3];
+        var repo       = commitInfo[4];
+        var commitId   = commitInfo[6];
+        var patchLink  = "https://bitbucket.org/api/2.0/repositories/" + project + "/" + repo + "/commit/" + commitId;
+        var commitJson = client.sendGet(patchLink);
+        var patches    = new HashSet<Patch>();
+
+        try {
+            var commitObj = (JSONObject) jsonParser.parse(commitJson);
+            var date      = new DateTime(commitObj.get("date").toString()).toString(ISODateTimeFormat.date());
+            var diffLink  = patchLink.replace("/commit/", "/diff/");
+            var rawDiff   = client.sendGet(diffLink);
+            patches = DiffParser.getPatchesFromDiffs(rawDiff);
+            patches.forEach(p -> {
+                p.setPatchDate(date);
+                p.setPatchUrl(ref);
+            });
+        } catch (Exception e) {
+            logger.error("Could not parse BitBucketCommit: " + ref);
         }
-        return null;
+        return patches;
     }
 
     /**
@@ -92,27 +88,26 @@ public class BitBucketRanger {
      * @param ref - link to a Bitbucket pull-request
      * @return - set of patches
      */
-    public HashSet<Vulnerability.Patch> parseBitBucketPullRequest(String ref) {
+    public HashSet<Patch> parseBitBucketPullRequest(String ref) {
         logger.info("Parsing BitBucket pull request with URL: " + ref);
-        var prInfo = ref.split("/");
-        var project = prInfo[3];
-        var repo = prInfo[4];
-        var prId = prInfo[6];
-        ref = "https://bitbucket.org/api/2.0/repositories/" + project + "/" + repo + "/pullrequests/" + prId;
-        var prJson = client.sendGet(ref);
+        var prInfo    = ref.split("/");
+        var project   = prInfo[3];
+        var repo      = prInfo[4];
+        var prId      = prInfo[6];
+        var patchLink = "https://bitbucket.org/api/2.0/repositories/" + project + "/" + repo + "/pullrequests/" + prId;
+        var prJson    = client.sendGet(patchLink);
         if (!prJson.contains("Not Found")) {
-            JSONObject prObj = null;
             try {
-                prObj = (JSONObject) jsonParser.parse(prJson);
-            } catch (ParseException e) {
-                e.printStackTrace();
-            }
-            if (prObj.get("merge_commit") != null) {
-                var mergeCommitObj = (JSONObject) prObj.get("merge_commit");
-                var mergeCommitHash = mergeCommitObj.get("hash");
-                var linkToCommit = "https://bitbucket.org/" + project
-                        + "/" + repo + "/commits/" + mergeCommitHash;
-                return PatchFinder.parseReference(linkToCommit);
+                var prObj = (JSONObject) jsonParser.parse(prJson);
+                if (prObj.get("merge_commit") != null) {
+                    var mergeCommitObj = (JSONObject) prObj.get("merge_commit");
+                    var mergeCommitHash = mergeCommitObj.get("hash");
+                    var linkToCommit = "https://bitbucket.org/" + project
+                            + "/" + repo + "/commits/" + mergeCommitHash;
+                    return PatchFinder.parseReference(linkToCommit);
+                }
+            } catch (Exception e) {
+                logger.error("Could not parse BitBucket PR: " + ref);
             }
         }
         return null;
@@ -124,43 +119,34 @@ public class BitBucketRanger {
      * @param ref - link to a Bitbucket issue
      * @return - set of patches
      */
-    public HashSet<Vulnerability.Patch> parseBitBucketIssue(String ref) {
+    public HashSet<Patch> parseBitBucketIssue(String ref) {
         logger.info("Parsing BitBucket issue with URL: " + ref);
-        HashSet<Vulnerability.Patch> patches = new HashSet<>();
-        var prInfo = ref.split("/");
-        var project = prInfo[3];
-        var repo = prInfo[4];
+        var patches = new HashSet<Patch>();
+        var prInfo      = ref.split("/");
+        var project     = prInfo[3];
+        var repo        = prInfo[4];
         var issueNumber = prInfo[6];
         var refAttachments = "https://bitbucket.org/api/2.0/repositories/" + project + "/" + repo + "/issues/" + issueNumber + "/attachments";
-        var refComments = "https://bitbucket.org/api/2.0/repositories/" + project + "/" + repo + "/issues/" + issueNumber + "/comments";
+        var refComments    = "https://bitbucket.org/api/2.0/repositories/" + project + "/" + repo + "/issues/" + issueNumber + "/comments";
         try {
-            // Parse attachments
             var issueAttachmentsJson = client.sendGet(refAttachments);
             if (!issueAttachmentsJson.contains("\"message\": \"No Issue matches the given query.\"")) {
                 var issueAttachments = (JSONArray) ((JSONObject) jsonParser.parse(issueAttachmentsJson)).get("values");
                 for (Object obj : issueAttachments) {
                     if (((JSONObject) obj).get("name").toString().contains(".patch")) {
-                        // Get the link and parse the patch
-                        var links = (JSONArray)
-                                ((JSONObject)
-                                        ((JSONObject)
-                                                ((JSONObject) obj)
-                                                        .get("links"))
-                                                .get("self"))
-                                        .get("href");
+                        var links = (JSONArray) ((JSONObject) ((JSONObject) ((JSONObject) obj).get("links")).get("self")).get("href");
                         for (Object link : links) {
                             var patchInfoInFile = client.sendGet((String) link);
-                            try {
-                                patches.addAll(DiffParser.getPatchesFromDiffs(patchInfoInFile));
-                            } catch (Exception e) {
-                                logger.error("Cannot parse the Bitbucket diff attachment, sorry");
-                            }
+                            var patchFromAttach = DiffParser.getPatchesFromDiffs(patchInfoInFile);
+                            patchFromAttach.forEach(p -> {
+                                p.setPatchUrl(link.toString());
+                            });
+                            patches.addAll(patchFromAttach);
                         }
                     }
                 }
             }
 
-            // Parse comments
             var issueCommentsJson = client.sendGet(refComments);
             if (!issueCommentsJson.contains("\"message\": \"No Issue matches the given query.\"")) {
                 var issueComments = (JSONArray) ((JSONObject) jsonParser.parse(issueCommentsJson)).get("values");
@@ -173,9 +159,8 @@ public class BitBucketRanger {
                     }
                 }
             }
-        } catch (ParseException e) {
-            logger.error("Could not parse " + ref + " attachments");
-            return null;
+        } catch (Exception e) {
+            logger.error("Could not parse BitBucket Issue: " + ref);
         }
         return patches;
     }

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/DiffParser.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/DiffParser.java
@@ -18,7 +18,8 @@
 
 package eu.fasten.vulnerabilityproducer.utils.patches;
 
-import eu.fasten.vulnerabilityproducer.utils.Vulnerability;
+import eu.fasten.vulnerabilityproducer.utils.*;
+import eu.fasten.vulnerabilityproducer.utils.Vulnerability.*;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
@@ -37,30 +38,19 @@ public class DiffParser {
      * @param diffs - diffs of the patch to be parsed.
      * @return set of Patches
      */
-    public static HashSet<Vulnerability.Patch> getPatchesFromDiffs(String diffs) throws Exception {
-        HashSet<Vulnerability.Patch> patches = new HashSet<>();
-        String patchDate = null;
-        String[] hunks = diffs.split("(\n|^)--- ");
+    public static HashSet<Patch> getPatchesFromDiffs(String diffs) throws Exception {
+        var patches = new HashSet<Patch>();
+        var hunks = diffs.split("(\n|^)--- ");
         for (int i = 1; i < hunks.length; i++) {
-            Vulnerability.Patch patch = new Vulnerability.Patch();
+            var patch = new Patch();
             var filename = hunks[i].split("\n")[0].split("\\t")[0].split("\\s")[0];
             if (filename.startsWith("a/"))  filename = filename.substring(2);
-            // A new file has been created
-            if (filename.equals("/dev/null")) {
-                continue;
-            }
-            // Processing a patch in a patch causes problems
-            if (filename.endsWith(".patch")) {
-                return patches;
-            }
-            patchDate = getPatchDate(hunks[i]);
-            List<Integer> lineChanged = getPatchHunks(hunks[i]);
-            // Fill in the patch
+            if (filename.equals("/dev/null")) continue;  // new file created
+            var patchDate = getPatchDate(hunks[i]);
+            var lineChanged = getPatchHunks(hunks[i]);
             if (lineChanged.size() > 0) {
-                patch.setFileName(filename);
-                patch.setLineNumbers(lineChanged);
-                patch.setPatchDate(patchDate);
-                patches.add(patch);
+                patch.setFileName(filename);    patch.setLineNumbers(lineChanged);
+                patch.setPatchDate(patchDate);  patches.add(patch);
             }
         }
         return patches;
@@ -73,8 +63,8 @@ public class DiffParser {
      * @return
      */
     public static List<Integer> getPatchHunks(String patch) throws Exception {
-        List<Integer> linesAffected = new ArrayList<>();
-        String[] linesPatch = patch.split("\n");
+        var linesAffected = new ArrayList<Integer>();
+        var linesPatch = patch.split("\n");
         var fromCache  = -1;
         var toCache    = -1;
         for (int i = 0; i < linesPatch.length; i++) {

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/DiffParser.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/DiffParser.java
@@ -18,7 +18,6 @@
 
 package eu.fasten.vulnerabilityproducer.utils.patches;
 
-import eu.fasten.vulnerabilityproducer.utils.*;
 import eu.fasten.vulnerabilityproducer.utils.Vulnerability.*;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/ExtraRanger.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/ExtraRanger.java
@@ -2,6 +2,7 @@ package eu.fasten.vulnerabilityproducer.utils.patches;
 
 import eu.fasten.vulnerabilityproducer.utils.PatchFinder;
 import eu.fasten.vulnerabilityproducer.utils.Vulnerability;
+import eu.fasten.vulnerabilityproducer.utils.Vulnerability.*;
 import eu.fasten.vulnerabilityproducer.utils.connections.JavaHttpClient;
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
@@ -26,9 +27,9 @@ public class ExtraRanger extends GenericRanger {
      * @param ref - link to a commit that uses cgit
      * @return - set of patches
      */
-    public HashSet<Vulnerability.Patch> parseGitTrackerCommit(String ref) {
+    public HashSet<Patch> parseGitTrackerCommit(String ref) {
         logger.info("Parsing Git tracker commit with URL: " + ref);
-        var patches = new HashSet<Vulnerability.Patch>();
+        var patches = new HashSet<Patch>();
         try {
             if (ref.matches("http(s)?://.*git\\..*\\.(org|com)/.*/commit/(\\?id=)?[a-zA-Z_0-9]++")) {
                 var linkToDiff = ref.replaceFirst("/commit/", "/rawdiff/");
@@ -41,8 +42,8 @@ public class ExtraRanger extends GenericRanger {
             }
         } catch (Exception e) {
             logger.error("Could not parse " + ref + " for Git Tracker");
-            return patches;
         }
+        patches.forEach(p -> p.setPatchUrl(ref));
         return patches;
     }
 
@@ -51,24 +52,24 @@ public class ExtraRanger extends GenericRanger {
      * @param ref - link to a revision
      * @return - set of patches
      */
-    public HashSet<Vulnerability.Patch> parseApacheSVNRevision(String ref) {
+    public HashSet<Patch> parseApacheSVNRevision(String ref) {
         logger.info("Parsing Apache SVN revision with URL: " + ref);
-        HashSet<Vulnerability.Patch> patches = new HashSet<>();
-        String baseURL = "https://svn.apache.org";
-        org.jsoup.nodes.Document doc = null;
-        String revisionHTML = httpClient.sendGet(ref);
-        doc = Jsoup.parse(revisionHTML);
-        Elements links = doc.select("a[title=\"View Diff\"]");
+        var patches = new HashSet<Patch>();
+        var baseURL = "https://svn.apache.org";
+        var revisionHTML = httpClient.sendGet(ref);
+        var doc   = Jsoup.parse(revisionHTML);
+        var links = doc.select("a[title=\"View Diff\"]");
         for (Element link : links) {
-            var patchLink = baseURL + link.attr("href") + "&view=patch";
-            var diff = httpClient.sendGet(patchLink);
             try {
+                var patchLink = baseURL + link.attr("href") + "&view=patch";
+                var diff = httpClient.sendGet(patchLink);
                 var patched_files = DiffParser.getPatchesFromDiffs(diff);
                 patches.addAll(patched_files);
             } catch (Exception e) {
-                logger.error("Cannot parse the diff for SVN Revision, sorry");
+                logger.error("Cannot parse the diff for SVN Revision: " + ref);
             }
         }
+        patches.forEach(p -> p.setPatchUrl(ref));
         return patches;
     }
 
@@ -78,23 +79,19 @@ public class ExtraRanger extends GenericRanger {
      * @param ref - link to a mailing thread
      * @return - set of patches
      */
-    public HashSet<Vulnerability.Patch> parseApacheMailThread(String ref) {
+    public HashSet<Patch> parseApacheMailThread(String ref) {
         logger.info("Parsing Mailing Thread with URL: " + ref);
-        HashSet<Vulnerability.Patch> patches = new HashSet<>();
+        var patches = new HashSet<Patch>();
         var linkToApiCall = ref.replace("thread.html", "api/source.lua");
         var threadRaw = httpClient.sendGet(linkToApiCall);
         if (threadRaw != null && threadRaw.contains("Content-Type: text/plain;")) {
-            // Strip only the content of it
             threadRaw = threadRaw.split("Content-Type: text/plain;")[1]
                     .split("Content-Type: text/html;")[0];
             var potentialPatches = PatchFinder.findPatchLinks(threadRaw);
             for (String pp : potentialPatches) {
-                // Checks for circular dep.
-                if (pp != ref) {
+                if (!pp.equals(ref)) {
                     var out = PatchFinder.parseReference(pp);
-                    if (out != null) {
-                        patches.addAll(out);
-                    }
+                    if (out != null) patches.addAll(out);
                 }
             }
         }
@@ -106,22 +103,23 @@ public class ExtraRanger extends GenericRanger {
      * @param ref - ref to mercurial revision
      * @return set of patches found
      */
-    public HashSet<Vulnerability.Patch> parseMercurialRevision(String ref) {
+    public HashSet<Patch> parseMercurialRevision(String ref) {
         logger.info("Parsing Mercurial Revision with URL: " + ref);
-        ref = ref.replace("rev", "raw-rev");
-        var content = httpClient.sendGet(ref);
-        if (content.contains("error: unknown revision")) {
-            return null;
-        }
-        var date = getDateFromMercurialRevision(content);
+        var patches   = new HashSet<Patch>();
+        var patchLink = ref.replace("rev", "raw-rev");
         try {
-            var patches = new HashSet<>(DiffParser.getPatchesFromDiffs(content));
-            patches.forEach(p -> p.setPatchDate(date));
-            return patches;
+            var content   = httpClient.sendGet(patchLink);
+            if (content.contains("error: unknown revision")) return null;
+            var date = getDateFromMercurialRevision(content);
+            patches.addAll((DiffParser.getPatchesFromDiffs(content)));
+            patches.forEach(p -> {
+                p.setPatchDate(date);
+                p.setPatchUrl(ref);
+            });
         } catch (Exception e) {
             logger.error("Could not parse HG Revision" + ref );
-            return null;
         }
+        return patches;
     }
 
     /**

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/ExtraRanger.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/ExtraRanger.java
@@ -36,13 +36,14 @@ public class ExtraRanger extends GenericRanger {
                 var raw = httpClient.sendGet(linkToDiff);
                 patches = DiffParser.getPatchesFromDiffs(raw);
             } else if (ref.contains(";a=commitdiff;")) {
-                var linkToDiff = ref.replace(";a=commitdiff;", ";a=commitdiff_plain;");
+                var linkToDiff = ref.replace("a=commitdiff", "a=commitdiff_plain");
                 var raw = httpClient.sendGet(linkToDiff);
                 patches = DiffParser.getPatchesFromDiffs(raw);
             }
         } catch (Exception e) {
             logger.error("Could not parse " + ref + " for Git Tracker");
         }
+        // TODO: Encode patch as vcs_url
         patches.forEach(p -> p.setPatchUrl(ref));
         return patches;
     }
@@ -69,6 +70,7 @@ public class ExtraRanger extends GenericRanger {
                 logger.error("Cannot parse the diff for SVN Revision: " + ref);
             }
         }
+        // TODO: Encode patch as vcs_url
         patches.forEach(p -> p.setPatchUrl(ref));
         return patches;
     }

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/GitHubRanger.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/GitHubRanger.java
@@ -228,6 +228,8 @@ public class GitHubRanger extends GenericRanger{
         logger.info("Parsing commit with URL: " + patchLink);
         var vp = new HashSet<Patch>();
         var infoPatch = patchLink.split("/");
+        var repoOwner = infoPatch[3];
+        var repoName = infoPatch[4];
         var commitHash = infoPatch[6];
 
         String jsonBody = null;
@@ -239,8 +241,6 @@ public class GitHubRanger extends GenericRanger{
         }
 
         if (jsonBody == null) {
-            var repoOwner = infoPatch[3];
-            var repoName = infoPatch[4];
             var apiLink = "https://api.github.com/repos/" + repoOwner + "/" + repoName + "/commits/" + commitHash;
             jsonBody = httpClient.sendGet(apiLink);
             if (jsonBody.contains("\"message\":\"Not Found\"")
@@ -268,6 +268,7 @@ public class GitHubRanger extends GenericRanger{
                 try {
                     var hunks = DiffParser.getPatchHunks(fileObj.get("patch").toString());
                     if (hunks.size() > 0) {
+                        patchLink = "git://github.com/" + repoOwner + "/" + repoName + "@" + commitHash;
                         vp.add(new Patch(filenameChanged, date, hunks, patchLink));
                     }
                 } catch (Exception e) {

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/GitHubRanger.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/GitHubRanger.java
@@ -43,7 +43,7 @@ import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 
 public class GitHubRanger extends GenericRanger{
-    GitHubAPI gitHubAPI;
+    public GitHubAPI gitHubAPI;
     public static MongoCollection<Document> mongoCommitsCollection;
     public static MongoCollection<Document> mongoPullRequestsCollection;
     public static MongoCollection<Document> mongoIssuesCollection;
@@ -89,7 +89,6 @@ public class GitHubRanger extends GenericRanger{
 
         String jsonBody = null;
         if (ghTorrentAvailable) {
-            // Query GHTorrent to find the corresponding Pull Request
             Bson filter = and(eq("repo", repoName),
                     eq("owner", repoOwner),
                     eq("number", prNumber));
@@ -107,8 +106,6 @@ public class GitHubRanger extends GenericRanger{
             }
         }
 
-        // Look for a merge_commit_sha and use the parseCommit function
-        // Parse the result and extract data
         Object obj = null;
         try {
             obj = jsonParser.parse(jsonBody);
@@ -117,7 +114,6 @@ public class GitHubRanger extends GenericRanger{
         }
         var payload = (JSONObject) obj;
         if (payload.get("merge_commit_sha") != null) {
-            // There is a commit we can parse
             var mergeCommitSHA = (String) payload.get("merge_commit_sha");
             var urlCommit = "https://github.com/" + repoOwner + "/" + repoName + "/commit/" + mergeCommitSHA;
             vp = this.parseGHCommit(urlCommit);
@@ -128,31 +124,18 @@ public class GitHubRanger extends GenericRanger{
     /**
      * Method parses Github issues links found in the vulnerability references.
      *
-     * @param issue         - link of the issue e.g. https://github.com/restlet/restlet-framework-java/issues/774
-     *                      <p>
-     *                      The script looks for a pull_request field in the json corresponding to the issue.
-     *                      "pull_request": {
-     *                      "url": "https://api.github.com/repos/python/cpython/pulls/32",
-     *                      "html_url": "https://github.com/python/cpython/pull/32",
-     *                      "diff_url": "https://github.com/python/cpython/pull/32.diff",
-     *                      "patch_url": "https://github.com/python/cpython/pull/32.patch"
-     *                      }
-     * @return
+     * @param issue Link to a GitHub issue to parse
+     * @return set of patches
      */
     public HashSet<Vulnerability.Patch> parseGHIssue(String issue) {
         logger.info("Parsing issue with URL: " + issue);
-        // Validation URL and eventual cleanup
-        if (issue.contains("#")) {
-            issue = issue.split("#")[0];
-            logger.info("Issue URL cleaned: " + issue);
-        }
+        issue = issue.split("#")[0];
 
-        var vp = new HashSet<Vulnerability.Patch>();
+        var vp   = new HashSet<Vulnerability.Patch>();
         var refs = new HashSet<String>();
-        // Extract information from the patch and create API Link
-        var infoPatch = issue.split("/");
-        var repoOwner = infoPatch[3];
-        var repoName = infoPatch[4];
+        var infoPatch   = issue.split("/");
+        var repoOwner   = infoPatch[3];
+        var repoName    = infoPatch[4];
         var issueNumber = infoPatch[6];
 
         String jsonBody = null;
@@ -172,8 +155,6 @@ public class GitHubRanger extends GenericRanger{
             }
         }
 
-        // Look for a pull_request and use the parsePullRequest function
-        // Parse the result and extract data
         Object obj = null;
         try {
             obj = jsonParser.parse(jsonBody);
@@ -182,13 +163,10 @@ public class GitHubRanger extends GenericRanger{
         }
         var payload = (JSONObject) obj;
         if (payload.get("pull_request") != null) {
-            // There is a commit we can parse
             var pullRequest = (JSONObject) payload.get("pull_request");
             var urlPullRequest = (String) pullRequest.get("html_url");
             vp = this.parseGHPullRequest(urlPullRequest);
         } else {
-            // Extra checks to get more information out of it
-            // PRs mentioning issues
             var prsMentionIssue = gitHubAPI.getPRsMentioningIssue(repoOwner, repoName, issueNumber);
             if (prsMentionIssue.size() > 0) {
                 logger.info("Found " + prsMentionIssue.size() + " PRs mentioning issue from "
@@ -200,8 +178,6 @@ public class GitHubRanger extends GenericRanger{
                 }
             }
 
-
-            // Get commit closing the issue
             var commitsClosingIssue = gitHubAPI.getCommitClosingIssue(repoOwner, repoName, issueNumber);
             if (commitsClosingIssue != null && !refs.contains(commitsClosingIssue)) {
                 logger.info("Found " + commitsClosingIssue + " closing "
@@ -210,9 +186,7 @@ public class GitHubRanger extends GenericRanger{
                 if (pp != null) vp.addAll(pp);
             }
 
-            // Get commits that reference issue
-            var commitsReferencingIssue = gitHubAPI.getCommitsReferencingIssue(repoOwner,
-                    repoName, issueNumber);
+            var commitsReferencingIssue = gitHubAPI.getCommitsReferencingIssue(repoOwner, repoName, issueNumber);
             if (commitsReferencingIssue.size() > 0) {
                 logger.info("Found " + commitsReferencingIssue.size() + " commits referencing issue "
                         + repoOwner + "/" + repoName + "#" + issueNumber);
@@ -224,9 +198,7 @@ public class GitHubRanger extends GenericRanger{
                 }
             }
 
-            // Get comments and look for references
-            var potentialReferences = gitHubAPI.getReferencesInIssueComments(repoOwner,
-                    repoName, issueNumber);
+            var potentialReferences = gitHubAPI.getReferencesInIssueComments(repoOwner, repoName, issueNumber);
             if (potentialReferences.size() > 0) {
                 logger.info("Found " + potentialReferences.size() + " references in comments of issue "
                         + repoOwner + "/" + repoName + "#" + issueNumber);
@@ -250,8 +222,7 @@ public class GitHubRanger extends GenericRanger{
      *
      * @param patchLink     URL to the git commit
      */
-    public HashSet<Vulnerability.Patch> parseGHCommit(String patchLink) {
-        // Validation URL and eventual cleanup
+    public HashSet<Patch> parseGHCommit(String patchLink) {
         patchLink = patchLink.split("#")[0].split("\\?")[0];
 
         logger.info("Parsing commit with URL: " + patchLink);
@@ -261,25 +232,24 @@ public class GitHubRanger extends GenericRanger{
 
         String jsonBody = null;
         if (ghTorrentAvailable) {
-            FindIterable<Document> mongoElement = mongoCommitsCollection.find(eq("sha", commitHash));
+            var mongoElement = mongoCommitsCollection.find(eq("sha", commitHash));
             if (mongoElement.first() != null) {
                 jsonBody = mongoElement.first().toJson();
             }
         }
 
-        // If GHTorrent does not find it, query Github API
         if (jsonBody == null) {
             var repoOwner = infoPatch[3];
             var repoName = infoPatch[4];
             var apiLink = "https://api.github.com/repos/" + repoOwner + "/" + repoName + "/commits/" + commitHash;
             jsonBody = httpClient.sendGet(apiLink);
-            if (jsonBody.contains("\"message\":\"Not Found\"") || jsonBody.contains("\"message\":\"No commit found for SHA")
+            if (jsonBody.contains("\"message\":\"Not Found\"")
+            || jsonBody.contains("\"message\":\"No commit found for SHA")
             || jsonBody.contains("\"message\":\"Git Repository is empty.\"")) {
                 return vp;
             }
         }
 
-        // Parse the result and extract data
         Object obj = null;
         try {
             obj = jsonParser.parse(jsonBody);
@@ -294,13 +264,11 @@ public class GitHubRanger extends GenericRanger{
         for (Object file : files) {
             var fileObj = (JSONObject) file;
             var filenameChanged = (String) fileObj.get("filename");
-            if (filenameChanged.endsWith(".patch") || filenameChanged.endsWith(".diff")) continue;
             if (fileObj.get("patch") != null) {
                 try {
                     var hunks = DiffParser.getPatchHunks(fileObj.get("patch").toString());
                     if (hunks.size() > 0) {
-                        var p = new Patch(filenameChanged, date, hunks);
-                        vp.add(p);
+                        vp.add(new Patch(filenameChanged, date, hunks, patchLink));
                     }
                 } catch (Exception e) {
                     logger.error("Could not parse the diff for " + filenameChanged + " in GH Commit " + patchLink);

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/GitLabRanger.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/GitLabRanger.java
@@ -64,11 +64,12 @@ public class GitLabRanger extends GenericRanger {
             var date = new DateTime(payload.get("created_at")).toString(ISODateTimeFormat.date());
             var linkToDiff = payload.get("web_url") + ".diff";
             var rawDiff = httpClient.sendGet(linkToDiff);
-                patches = DiffParser.getPatchesFromDiffs(rawDiff);
-                patches.forEach(patch -> {
-                    patch.setPatchDate(date);
-                    patch.setPatchUrl(ref);
-                });
+            patches = DiffParser.getPatchesFromDiffs(rawDiff);
+            var vcsPatch = "git://" + base + "/" + org + "/" + project + "@" + commitSha;
+            patches.forEach(patch -> {
+                patch.setPatchDate(date);
+                patch.setPatchUrl(vcsPatch);
+            });
         } catch (Exception e) {
             logger.error("Could not parse GitLab commit: " + ref);
         }

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/GitLabRanger.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/GitLabRanger.java
@@ -19,6 +19,7 @@
 package eu.fasten.vulnerabilityproducer.utils.patches;
 
 import eu.fasten.vulnerabilityproducer.utils.Vulnerability;
+import eu.fasten.vulnerabilityproducer.utils.Vulnerability.*;
 import eu.fasten.vulnerabilityproducer.utils.connections.JavaHttpClient;
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
@@ -47,34 +48,31 @@ public class GitLabRanger extends GenericRanger {
      */
     public HashSet<Vulnerability.Patch> parseGLCommit(String ref) {
         logger.info("Parsing GitLab commit with URL: " + ref);
-        HashSet<Vulnerability.Patch> patches = new HashSet<>();
-        var values = ref.split("/");
+        var patches = new HashSet<Patch>();
+        var values  = ref.split("/");
         var base = values[2];
-        var org = values[3];
-        var project = values[4];
+        var org  = values[3];
+        var project   = values[4];
         var commitSha = values[7];
         var projectId = getGitLabProjectId(base, org, project);
-        var linkToCommit = "https://" + base + "/api/v4/projects/"+ projectId +"/repository/commits/"
-                + commitSha;
-        var commitJson = httpClient.sendGet(linkToCommit);
+        var linkToCommit = "https://" + base + "/api/v4/projects/"+ projectId +"/repository/commits/" + commitSha;
+        var commitJson   = httpClient.sendGet(linkToCommit);
         if (commitJson.contains("404 Commit Not Found"))    return patches;
 
-        JSONObject payload = null;
         try {
-            payload = (JSONObject) jsonParser.parse(commitJson);
-        } catch (ParseException e) {
-            e.printStackTrace();
-        }
-        String date = new DateTime(payload.get("created_at")).toString(ISODateTimeFormat.date());
-        var linkToDiff = payload.get("web_url") + ".diff";
-        var rawDiff = httpClient.sendGet(linkToDiff);
-        try {
-            patches = DiffParser.getPatchesFromDiffs(rawDiff);
-            patches.forEach(patch -> patch.setPatchDate(date));
-            return patches;
+            var payload = (JSONObject) jsonParser.parse(commitJson);
+            var date = new DateTime(payload.get("created_at")).toString(ISODateTimeFormat.date());
+            var linkToDiff = payload.get("web_url") + ".diff";
+            var rawDiff = httpClient.sendGet(linkToDiff);
+                patches = DiffParser.getPatchesFromDiffs(rawDiff);
+                patches.forEach(patch -> {
+                    patch.setPatchDate(date);
+                    patch.setPatchUrl(ref);
+                });
         } catch (Exception e) {
-            return null;
+            logger.error("Could not parse GitLab commit: " + ref);
         }
+        return patches;
     }
 
     /**
@@ -86,41 +84,35 @@ public class GitLabRanger extends GenericRanger {
      */
     public HashSet<Vulnerability.Patch> parseGLIssue(String ref) {
         logger.info("Parsing GitLab issue with URL: " + ref);
-        var values = ref.split("/");
-        var base = values[2];
-        var org = values[3];
+        var values  = ref.split("/");
+        var base    = values[2];
+        var org     = values[3];
         var project = values[4];
         var issuesNumber = ref.split("/")[7];
-        var projectId = getGitLabProjectId(base, org, project);
-        HashSet<Vulnerability.Patch> patches = new HashSet<>();
-        // Get related merge_requests
-        var linkMrs = "https://" + base + "/api/v4/projects/"+ projectId +"/issues/"
-                + issuesNumber + "/related_merge_requests";
-        var mrJson = httpClient.sendGet(linkMrs);
-        JSONArray payload = null;
+        var projectId    = getGitLabProjectId(base, org, project);
+        var patches = new HashSet<Patch>();
+        var linkMrs = "https://" + base + "/api/v4/projects/"+ projectId +
+                      "/issues/" + issuesNumber + "/related_merge_requests";
+        var mrJson  = httpClient.sendGet(linkMrs);
         try {
-            payload = (JSONArray) jsonParser.parse(mrJson);
-        } catch (ParseException e) {
-            e.printStackTrace();
-        }
-        for (Object element : payload) {
-            JSONObject mr = (JSONObject) element;
-            // Check merge_commit and parse the diff
-            if (mr.get("merge_commit_sha") != null) {
-                // Extract date
-                String date = new DateTime(mr.get("merged_at")).toString(ISODateTimeFormat.date());
-                // Get the diffs and parse them
-                var linkToDiff = "https://"+ base +"/" + org + "/" + project + "/-/"
-                        + "commit/" + mr.get("merge_commit_sha") + ".diff";
-                var rawDiff = httpClient.sendGet(linkToDiff);
-                try {
+            var payload = (JSONArray) jsonParser.parse(mrJson);
+            for (Object element : payload) {
+                var mr = (JSONObject) element;
+                if (mr.get("merge_commit_sha") != null) {
+                    var date = new DateTime(mr.get("merged_at")).toString(ISODateTimeFormat.date());
+                    var linkToDiff = "https://" + base + "/" + org + "/" + project + "/-/"
+                                   + "commit/" + mr.get("merge_commit_sha") + ".diff";
+                    var rawDiff = httpClient.sendGet(linkToDiff);
                     var fixingPatches = DiffParser.getPatchesFromDiffs(rawDiff);
-                    fixingPatches.forEach(patch -> patch.setPatchDate(date));
+                    fixingPatches.forEach(patch -> {
+                        patch.setPatchDate(date);
+                        patch.setPatchUrl(ref);
+                    });
                     patches.addAll(fixingPatches);
-                } catch (Exception e) {
-                    logger.error("Could not parse GL diff: " + linkToDiff);
                 }
             }
+        } catch (Exception e) {
+            logger.error("Could not parse GitLab issue: " + ref);
         }
         return patches;
     }
@@ -134,47 +126,36 @@ public class GitLabRanger extends GenericRanger {
      */
     public HashSet<Vulnerability.Patch> parseGLMergeRequest(String ref) {
         logger.info("Parsing GitLab merge request with URL: " + ref);
-        var patches = new HashSet<Vulnerability.Patch>();
-        var values = ref.split("/");
-        var base = values[2];
-        var org = values[3];
-        var project = values[4];
-        var mrNumber = values[7];
+        var patches   = new HashSet<Vulnerability.Patch>();
+        var values    = ref.split("/");
+        var base      = values[2];
+        var org       = values[3];
+        var project   = values[4];
+        var mrNumber  = values[7];
         var projectId = getGitLabProjectId(base, org, project);
-        var linkToMr = "https://" + base + "/api/v4/projects/"+ projectId +"/merge_requests/"
-                + mrNumber;
+        var linkToMr  = "https://" + base + "/api/v4/projects/"+ projectId +"/merge_requests/" + mrNumber;
         var mrJson = httpClient.sendGet(linkToMr);
         if (mrJson.contains("404 Not Found"))    return patches;
 
-        JSONObject payload = null;
         try {
-            payload = (JSONObject) jsonParser.parse(mrJson);
-        } catch (ParseException e) {
-            e.printStackTrace();
-        }
-        String date = new DateTime(payload.get("merged_at")).toString(ISODateTimeFormat.date());
-        String linkToDiff = null;
-        if (payload.get("merge_commit_sha") != null) {
-            linkToDiff = "https://" + base + "/" + org + "/" + project + "/-/commit/"
-                    + payload.get("merge_commit_sha") + ".diff";
-        }
-        if (linkToDiff == null && payload.get("sha") != null) {
-            linkToDiff = "https://" + base + "/" + org + "/" + project + "/-/commit/"
-                    + payload.get("sha") + ".diff";
-        }
-        if (linkToDiff != null) {
-            var rawDiff = httpClient.sendGet(linkToDiff);
-            try {
-                patches = DiffParser.getPatchesFromDiffs(rawDiff);
-                patches.forEach(patch -> patch.setPatchDate(date));
-                return patches;
-            } catch (Exception e) {
-                logger.error("Could not parse GL MR: " + ref);
-                return null;
-            }
-        }
+            var payload = (JSONObject) jsonParser.parse(mrJson);
+            var date = new DateTime(payload.get("merged_at")).toString(ISODateTimeFormat.date());
+            var linkToDiff = "https://" + base + "/" + org + "/" + project + "/-/commit/";
+            if (payload.get("merge_commit_sha") != null)                      linkToDiff += (payload.get("merge_commit_sha") + ".diff");
+            if (!linkToDiff.endsWith(".diff") && payload.get("sha") != null)  linkToDiff += (payload.get("sha") + ".diff");
 
-        return null;
+            if (linkToDiff.endsWith(".diff")) {
+                var rawDiff = httpClient.sendGet(linkToDiff);
+                patches = DiffParser.getPatchesFromDiffs(rawDiff);
+                patches.forEach(patch -> {
+                    patch.setPatchDate(date);
+                    patch.setPatchUrl(ref);
+                });
+            }
+        } catch (Exception e) {
+            logger.error("Could not parse GitLab MR: " + ref);
+        }
+        return patches;
     }
 
     /**
@@ -187,16 +168,12 @@ public class GitLabRanger extends GenericRanger {
         var url = "https://" + base +"/api/v4/projects/" + org + "%2F" + project;
         var projectInfo = httpClient.sendGet(url);
         if (projectInfo.contains("404 Project Not Found"))  return null;
-        JSONObject payload = null;
         try {
-            payload = (JSONObject) jsonParser.parse(projectInfo);
+            var payload = (JSONObject) jsonParser.parse(projectInfo);
+            return payload.get("id") != null ? (Long) payload.get("id") : null;
         } catch (ParseException e) {
             e.printStackTrace();
         }
-        if (payload.get("id") != null) {
-            return (Long) payload.get("id");
-        } else {
-            return null;
-        }
+        return null;
     }
 }

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/JIRARanger.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/patches/JIRARanger.java
@@ -20,6 +20,7 @@ package eu.fasten.vulnerabilityproducer.utils.patches;
 
 import eu.fasten.vulnerabilityproducer.utils.PatchFinder;
 import eu.fasten.vulnerabilityproducer.utils.Vulnerability;
+import eu.fasten.vulnerabilityproducer.utils.Vulnerability.*;
 import eu.fasten.vulnerabilityproducer.utils.connections.JavaHttpClient;
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
@@ -48,68 +49,63 @@ public class JIRARanger extends GenericRanger {
      * @return - set of patches
      */
     public HashSet<Vulnerability.Patch> parseJIRATicket(String ref) {
-        // Clean JIRA link
         ref = ref.split("\\?")[0];
-        // If protected resource, just move on
         logger.info("Parsing JIRA Ticket with URL: " + ref);
-        HashSet<Vulnerability.Patch> patches = new HashSet<>();
+        var patches = new HashSet<Patch>();
         var jiraServer = ref.split("/browse/")[0];
         var ticketId = ref.split("/browse/")[1];
 
         var linkToJson = jiraServer + "/rest/api/2/issue/" + ticketId;
         var ticketJson = httpClient.sendGet(linkToJson);
-        if (ticketJson.contains("{\"errorMessages\":[\"Issue Does Not Exist\"]") ||
-                ticketJson.contains("To: issues@bookkeeper.apache.org")) {
+
+        if (ticketJson.contains("{\"errorMessages\":[\"Issue Does Not Exist\"]")) {
             return patches;
         }
-        // Extract each of the attachments, if the contain a patch, parse it
-        Object obj = null;
+
         try {
-            obj = jsonParser.parse(ticketJson);
-        } catch (ParseException e) {
-            e.printStackTrace();
-        }
-        JSONObject payload = (JSONObject) obj;
-        JSONObject fields = (JSONObject) payload.get("fields");
+            Object obj = jsonParser.parse(ticketJson);
+            var payload = (JSONObject) obj;
+            var fields = (JSONObject) payload.get("fields");
 
-        JSONArray attachments = (JSONArray) fields.get("attachment");
-        JSONArray comments = (JSONArray) ((JSONObject )fields.get("comment")).get("comments");
+            var attachments = (JSONArray) fields.get("attachment");
+            var comments = (JSONArray) ((JSONObject) fields.get("comment")).get("comments");
 
-        // Attachments
-        if (attachments != null) {
-            for (Object attachment : attachments) {
-                String linkToAttachment = (String) ((JSONObject) attachment).get("content");
-                if (linkToAttachment.endsWith(".patch")) {
-                    var rawPatch = httpClient.sendGet(linkToAttachment);
-                    // Parse the diffs
-                    try {
+            // Attachments
+            if (attachments != null) {
+                for (Object attachment : attachments) {
+                    var linkToAttachment = (String) ((JSONObject) attachment).get("content");
+                    if (linkToAttachment.endsWith(".patch")) {
+                        var rawPatch = httpClient.sendGet(linkToAttachment);
                         patches.addAll(DiffParser.getPatchesFromDiffs(rawPatch));
-                    } catch (Exception e) {
-                        logger.error("Could not parse JIRA Attachment with raw patch, sorry");
+                        var creationDate = new DateTime(((JSONObject) attachment).get("created")).toString(ISODateTimeFormat.date());
+                        patches.forEach(p -> {
+                            p.setPatchDate(creationDate);
+                            p.setPatchUrl(linkToAttachment);
+                        });
                     }
-                    // Get date of creation
-                    var creationDate = new DateTime(((JSONObject) attachment).get("created")).toString(ISODateTimeFormat.date());
-                    patches.forEach(p -> p.setPatchDate(creationDate));
                 }
             }
-        }
 
-        // Comments
-        if (comments != null) {
-            var potentialPatches = new HashSet<String>();
-            for (Object comment : comments) {
-                String body = (String) ((JSONObject) comment).get("body");
-                potentialPatches.addAll(PatchFinder.findPatchLinks(body));
-            }
-            for (String pp : potentialPatches) {
-                // Checks for circular dep
-                if (pp != ref && !pp.contains(ref)) {
+            // Comments
+            if (comments != null) {
+                var potentialPatches = new HashSet<String>();
+                for (Object comment : comments) {
+                    var body = (String) ((JSONObject) comment).get("body");
+                    var pp = PatchFinder.findPatchLinks(body);
+                    var cpref = ref;
+                    pp.stream().filter(p -> !p.equals(cpref) && !p.contains(cpref));
+                    potentialPatches.addAll(pp);
+                }
+                for (String pp : potentialPatches) {
                     var vpp = PatchFinder.parseReference(pp);
-                    if (vpp != null && vpp.size() > 0) patches.addAll(vpp);
+                    if (vpp != null && vpp.size() > 0) {
+                        patches.addAll(vpp);
+                    }
                 }
             }
+        } catch (Exception e) {
+            logger.error("Could not parse JIRA ticket: " + ref);
         }
-
         return patches;
     }
 }

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/stats/Stats.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/stats/Stats.java
@@ -23,11 +23,11 @@ import net.steppschuh.markdowngenerator.table.Table;
 import net.steppschuh.markdowngenerator.text.heading.Heading;
 import org.apache.commons.io.FileUtils;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.*;
+import java.util.concurrent.atomic.*;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toSet;
@@ -140,5 +140,52 @@ public class Stats {
         } catch (MalformedURLException e) {
             return null;
         }
+    }
+
+    public static void storeCVEsWithPurls(List<Vulnerability> vulnerabilities) {
+        var cvesWithPurls = vulnerabilities.stream().filter(v -> v.getPurls().size() > 0)
+                .map(Vulnerability::getId).collect(Collectors.toList());
+        try {
+            var writer = new FileWriter("/path/to/file.txt");
+            for(String str: cvesWithPurls) {
+                writer.write(str + System.lineSeparator());
+            }
+            writer.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void printStats(HashMap<String, Vulnerability> vulns) {
+        printStats(new ArrayList<>(vulns.values()));
+    }
+
+    public static void printStats(PriorityQueue<Vulnerability> vulns) {
+        printStats(new ArrayList<>(vulns));
+    }
+
+    public static void printStats(ArrayList<Vulnerability> vulns) {
+        var vp     = new AtomicInteger();
+        var vp_mvn = new AtomicInteger();
+        var vp_c   = new AtomicInteger();
+        var vp_py  = new AtomicInteger();
+
+        vulns.forEach(v -> {
+            if (v.getPurls().size() > 0) {
+                vp.addAndGet(1);
+                var base = v.getPurls().get(0).split("@")[0];
+                if (base.startsWith("pkg:maven"))    vp_mvn.addAndGet(1);
+                if (base.startsWith("pkg:pypi"))     vp_py.addAndGet(1);
+                if (base.startsWith("pkg:deb"))      vp_c.addAndGet(1);
+            }
+        });
+
+        System.out.println("");
+        System.out.println("Statistics:");
+        System.out.println("    Total Purls: " + vp.get());
+        System.out.println("          Maven Purls: " + vp_mvn.get());
+        System.out.println("           PyPI Purls: " + vp_py.get());
+        System.out.println("         Debian Purls: " + vp_c.get());
+        System.out.println("");
     }
 }

--- a/src/test/java/eu/fasten/vulnerabilityproducer/PatchFinderTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/PatchFinderTest.java
@@ -586,7 +586,8 @@ public class PatchFinderTest {
         patchFinder.parseReferences(v, nc);
 
         assertTrue(v.getPatches().contains(patch));
-        assertTrue(v.getPatchLinks().contains(commitLink));
+        var vcsPatch = "git://github.com/mongodb/mongo@443e8974d66a3ddd2ad89f8b3f9c2ebb7d8d9500";
+        assertTrue(v.getPatchLinks().contains(vcsPatch));
     }
 
     @Test

--- a/src/test/java/eu/fasten/vulnerabilityproducer/PatchFinderTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/PatchFinderTest.java
@@ -23,10 +23,10 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import eu.fasten.vulnerabilityproducer.db.NitriteController;
 import eu.fasten.vulnerabilityproducer.utils.PatchFinder;
+import eu.fasten.vulnerabilityproducer.utils.Vulnerability.*;
 import eu.fasten.vulnerabilityproducer.utils.connections.JavaHttpClient;
 import eu.fasten.vulnerabilityproducer.utils.Vulnerability;
-import eu.fasten.vulnerabilityproducer.utils.patches.BitBucketRanger;
-import eu.fasten.vulnerabilityproducer.utils.patches.ExtraRanger;
+import eu.fasten.vulnerabilityproducer.utils.patches.*;
 import org.apache.commons.io.FileUtils;
 import org.bson.Document;
 import org.bson.conversions.Bson;
@@ -43,7 +43,6 @@ import java.util.stream.Collectors;
 import static com.mongodb.client.model.Filters.eq;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 public class PatchFinderTest {
@@ -160,6 +159,31 @@ public class PatchFinderTest {
             "      * <code>java.security.MessageDigest</code> class on your platform.";
 
     final String errorJSON = "{\"code\":404,\"error\":\"Not found\"}";
+
+    final String diffOfDiff = "diff --git a/core/src/components/toolbar/test/spec/index.html b/core/src/components/toolbar/test/spec/index.html\n" +
+            "index 511b2958c26..4a6510855ac 100644\n" +
+            "--- a/core/src/components/toolbar/test/spec/index.html\n" +
+            "+++ b/core/src/components/toolbar/test/spec/index.html\n" +
+            "@@ -1,4 +1,3 @@\n" +
+            "-@@ -0,0 +1,59 @@\n" +
+            " <!DOCTYPE html>\n" +
+            " <html dir=\"ltr\">\n" +
+            " \n" +
+            "@@ -14,12 +13,12 @@\n" +
+            " \n" +
+            " <body>\n" +
+            "   <ion-app>\n" +
+            "-    <ion-header>\n" +
+            "+    <ion-content>\n" +
+            "       <ion-toolbar color=\"tertiary\">\n" +
+            "         <ion-buttons slot=\"start\">\n" +
+            "           <ion-menu-button auto-hide=\"false\"></ion-menu-button>\n" +
+            "         </ion-buttons>\n" +
+            "-        <ion-buttons slot=\"secondary\">\n" +
+            "+        <ion-buttons slot=\"primary\">\n" +
+            "           <ion-button>\n" +
+            "             <ion-icon slot=\"icon-only\" name=\"download\"></ion-icon>\n" +
+            "           </ion-button>";
 
     @BeforeEach
     public void setup() {
@@ -533,35 +557,36 @@ public class PatchFinderTest {
 
     @Test
     public void testParseJIRATicketComments() throws Exception {
-        String refLink = "https://jira.mongodb.org/browse/SERVER-40563";
-        String commitLink = "https://github.com/mongodb/mongo/commit/443e8974d66a3ddd2ad89f8b3f9c2ebb7d8d9500";
-        String jiraTicketApiJson = readFile("./src/test/resources/patches/jira_ticket_mongo_comments.json");
-        String patchCommitJson = readFile("./src/test/resources/patches/jira_ticket_mongo_commit.json");
+        var refLink = "https://jira.mongodb.org/browse/SERVER-40563";
+        var commitLink = "https://github.com/mongodb/mongo/commit/443e8974d66a3ddd2ad89f8b3f9c2ebb7d8d9500";
+        var jiraTicketApiJson = readFile("./src/test/resources/patches/jira_ticket_mongo_comments.json");
+        var patchCommitJson = readFile("./src/test/resources/patches/jira_ticket_mongo_commit.json");
 
         when(clientMock.sendGet("https://jira.mongodb.org/rest/api/2/issue/SERVER-40563"))
                 .thenReturn(jiraTicketApiJson);
 
-        FindIterable mockIterable = Mockito.mock(FindIterable.class);
+        var mockIterable = Mockito.mock(FindIterable.class);
         when(commitsMock.find((Bson) Mockito.any())).thenReturn(mockIterable);
-        Document mockDocument = Mockito.mock(Document.class);
+        var mockDocument = Mockito.mock(Document.class);
         when(mockIterable.first()).thenReturn(mockDocument);
         when(mockDocument.toJson()).thenReturn(null);
 
         when(clientMock.sendGet("https://api.github.com/repos/mongodb/mongo/commits/443e8974d66a3ddd2ad89f8b3f9c2ebb7d8d9500"))
                 .thenReturn(patchCommitJson);
 
-        NitriteController nc = Mockito.mock(NitriteController.class);
+        var nc = Mockito.mock(NitriteController.class);
         when(nc.findPatchEntry(refLink)).thenReturn(Optional.empty());
 
-        Vulnerability.Patch patch = new Vulnerability.Patch("rpm/init.d-mongod", new ArrayList<>(Arrays.asList(103, 111)));
+        var patch = new Patch("rpm/init.d-mongod", new ArrayList<>(Arrays.asList(103, 111)), commitLink);
         patch.setPatchDate("2019-05-24");
 
-        Vulnerability v = new Vulnerability("TEST");
+        var v = new Vulnerability("TEST");
         v.addReference(refLink);
 
         patchFinder.parseReferences(v, nc);
 
         assertTrue(v.getPatches().contains(patch));
+        assertTrue(v.getPatchLinks().contains(commitLink));
     }
 
     @Test
@@ -575,14 +600,14 @@ public class PatchFinderTest {
         when(clientMock.sendGet("https://bugs.kde.org/rest/bug/97608")).thenReturn(responseInfo);
         when(clientMock.sendGet("https://bugs.kde.org/rest/bug/97608/attachment")).thenReturn(responseAttach);
         when(clientMock.sendGet("https://bugs.kde.org/rest/bug/97608/comment")).thenReturn(responseComments);
-        NitriteController nc = Mockito.mock(NitriteController.class);
+        var nc = Mockito.mock(NitriteController.class);
         when(nc.findPatchEntry(ref)).thenReturn(Optional.empty());
 
-        Vulnerability.Patch patch = new Vulnerability.Patch("kdelibs-3.3.2/dcop/dcopidlng/dcopidlng",
+        var patch = new Vulnerability.Patch("kdelibs-3.3.2/dcop/dcopidlng/dcopidlng",
                 "2005-01-21",
                 new ArrayList<>(Arrays.asList(6, 10, 12)));
 
-        Vulnerability v = new Vulnerability("TEST");
+        var v = new Vulnerability("TEST");
         v.addReference(ref);
 
         patchFinder.parseReferences(v, nc);
@@ -1087,6 +1112,14 @@ public class PatchFinderTest {
                 "2017-11-05",
                 new ArrayList<>(Arrays.asList(343, 344, 348))));
         assertEquals(patches, v.getPatches());
+    }
+
+    @Test
+    public void testParserDiffOfDiff() throws Exception {
+        var patches = DiffParser.getPatchesFromDiffs(diffOfDiff);
+        var exPatches = new HashSet<Patch>();
+        exPatches.add(new Patch("core/src/components/toolbar/test/spec/index.html", null, Arrays.asList(17, 22)));
+        assertEquals(exPatches, patches);
     }
 }
 

--- a/src/test/java/eu/fasten/vulnerabilityproducer/mappers/PurlMapperTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/mappers/PurlMapperTest.java
@@ -20,6 +20,7 @@ package eu.fasten.vulnerabilityproducer.mappers;
 
 import eu.fasten.vulnerabilityproducer.utils.PatchFinder;
 import eu.fasten.vulnerabilityproducer.utils.Vulnerability;
+import eu.fasten.vulnerabilityproducer.utils.Vulnerability.*;
 import eu.fasten.vulnerabilityproducer.utils.mappers.PurlMapper;
 import eu.fasten.vulnerabilityproducer.utils.mappers.VersionRanger;
 import org.joda.time.DateTime;
@@ -66,9 +67,9 @@ public class PurlMapperTest {
     public void inferPurlMissing() {
         purlMapper.pypiMap.put("https://github.com/python/django", "pkg:pypi/django");
         var versions = new ArrayList<String>(); versions.add("pkg:pypi/django@1.9");
-        Vulnerability v = new Vulnerability();
+        var v = new Vulnerability();
         v.addPatchLink("https//github.com/python/django/commit/5326bi6b5u53b1u5ob1b5i265");
-        v.addPatch(new Vulnerability.Patch("oof.py", "2018-05-30",  null ));
+        v.addPatch(new Patch("oof.py", "2018-05-30",  null ));
 
         when(vrMock.getPurlsBeforeDate(Mockito.anyString(), Mockito.any())).thenReturn(versions);
         when(pfMock.getBaseRepo(v)).thenReturn("https://github.com/python/django");


### PR DESCRIPTION
The Parsers have been refactored. The Patch Object now contains a `patchUrl` field that indicates where exactly the diff was picked up. This allows us to be more specific in the reporting of `patchLinks` and in the evaluation of the accuracy of those links.