### PR TITLE
Fixes for yaml and directories

### DIFF
--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/YAMLHandler.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/YAMLHandler.java
@@ -481,7 +481,7 @@ public class YAMLHandler {
         }
 
         public String vulnerability_id;
-        public List<NoteTextMapper> notes;
+        public List<NoteMapper> notes;
         public List<FixMapper> fixes;
         public List<ArtifactMapper> artifacts;
 
@@ -493,11 +493,11 @@ public class YAMLHandler {
             this.vulnerability_id = vulnerability_id;
         }
 
-        public List<NoteTextMapper> getNotes() {
+        public List<NoteMapper> getNotes() {
             return notes;
         }
 
-        public void setNotes(List<NoteTextMapper> notes) {
+        public void setNotes(List<NoteMapper> notes) {
             this.notes = notes;
         }
 

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ExtraParser.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ExtraParser.java
@@ -94,24 +94,25 @@ public class ExtraParser implements VulnerabilityParser {
 
             while (keys.hasNext()) {
                 var key = keys.next();
-                var listVulns = (JSONArray) jsonObject.get(key);
-                for (Object listVuln : listVulns) {
-                    var vulnObject = (JSONObject) listVuln;
-                    var cveIds = vulnObject.get("cve");
-                    if (!cveIds.toString().equals("null")) {
-                        // There are multiple CVE-IDs
-                        if (cveIds.toString().contains(",")) {
-                            var cves = cveIds.toString().split(",\\s?");
-                            Arrays.stream(cves).forEach(cve -> insertVulnerability(injectInfoHelper(key, cve, vulnObject)));
+                var listVulns = jsonObject.optJSONArray(key);
+                if(Objects.nonNull(listVulns)) {
+                    for (Object listVuln : listVulns) {
+                        var vulnObject = (JSONObject) listVuln;
+                        var cveIds = vulnObject.get("cve");
+                        if (!cveIds.toString().equals("null")) {
+                            // There are multiple CVE-IDs
+                            if (cveIds.toString().contains(",")) {
+                                var cves = cveIds.toString().split(",\\s?");
+                                Arrays.stream(cves).forEach(cve -> insertVulnerability(injectInfoHelper(key, cve, vulnObject)));
+                            } else {
+                                // There is only one CVE-ID
+                                insertVulnerability(injectInfoHelper(key, cveIds.toString(), vulnObject));
+                            }
                         } else {
-                            // There is only one CVE-ID
-                            var cveId = cveIds;
-                            insertVulnerability(injectInfoHelper(key, cveId.toString(), vulnObject));
+                            // There is only PyUp-id
+                            var pyupId = (String) vulnObject.get("id");
+                            insertVulnerability(injectInfoHelper(key, pyupId, vulnObject));
                         }
-                    } else {
-                        // There is only PyUp-id
-                        var pyupId = (String) vulnObject.get("id");
-                        insertVulnerability(injectInfoHelper(key, pyupId, vulnObject));
                     }
                 }
             }

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/NVDParser.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/NVDParser.java
@@ -41,6 +41,7 @@ import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.time.LocalDate;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -104,15 +105,15 @@ public class NVDParser implements VulnerabilityParser {
      * @throws DownloadFailedException   - download fails
      * @throws ResourceNotFoundException - resource cannot be found
      */
-    public List<File> downloadCVEs() throws MalformedURLException,
+    public List<File> downloadCVEs() throws IOException,
             TooManyRequestsException,
-            DownloadFailedException,
             ResourceNotFoundException {
         int currentYear = LocalDate.now().getYear();
         List<File> paths = new ArrayList<>();
         for (int i = 2002; i <= currentYear; i++) {
             URL cve_url = new URL("https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-" + i + ".json.gz");
             File out_path = new File(mnt + "/nvd/nvdcve-1.1-" + i + ".json.gz");
+            Files.createDirectories(out_path.toPath());
             logger.info("Downloading NVD file for the year " + i);
             downloader.fetchFile(cve_url, out_path);
             paths.add(out_path);
@@ -129,12 +130,12 @@ public class NVDParser implements VulnerabilityParser {
      * @throws DownloadFailedException   - download fails
      * @throws ResourceNotFoundException - resource cannot be found
      */
-    public File downloadUpdates() throws MalformedURLException,
+    public File downloadUpdates() throws IOException,
             TooManyRequestsException,
-            DownloadFailedException,
             ResourceNotFoundException {
         var updates_url = new URL("https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz");
         var out_path = new File(mnt + "/nvd/nvdcve-1.1-modified.json.gz");
+        Files.createDirectories(out_path.toPath());
         downloader.fetchFile(updates_url, out_path);
         return out_path;
     }
@@ -225,13 +226,7 @@ public class NVDParser implements VulnerabilityParser {
                 this.downloader = new Downloader(new Settings(new Properties()));
             }
             paths = downloadCVEs();
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        } catch (TooManyRequestsException e) {
-            e.printStackTrace();
-        } catch (DownloadFailedException e) {
-            e.printStackTrace();
-        } catch (ResourceNotFoundException e) {
+        } catch (TooManyRequestsException | ResourceNotFoundException | IOException e) {
             e.printStackTrace();
         }
         List<DefCveItem> rawCves = new ArrayList<>();
@@ -264,13 +259,7 @@ public class NVDParser implements VulnerabilityParser {
                 this.downloader = new Downloader(new Settings(new Properties()));
             }
             pathToUpdates = downloadUpdates();
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        } catch (TooManyRequestsException e) {
-            e.printStackTrace();
-        } catch (DownloadFailedException e) {
-            e.printStackTrace();
-        } catch (ResourceNotFoundException e) {
+        } catch (TooManyRequestsException | ResourceNotFoundException | IOException e) {
             e.printStackTrace();
         }
         List<DefCveItem> rawCves = new ArrayList<>();

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/NVDParser.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/NVDParser.java
@@ -113,7 +113,7 @@ public class NVDParser implements VulnerabilityParser {
         for (int i = 2002; i <= currentYear; i++) {
             URL cve_url = new URL("https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-" + i + ".json.gz");
             File out_path = new File(mnt + "/nvd/nvdcve-1.1-" + i + ".json.gz");
-            Files.createDirectories(out_path.toPath());
+            Files.createDirectories(out_path.toPath().getParent());
             logger.info("Downloading NVD file for the year " + i);
             downloader.fetchFile(cve_url, out_path);
             paths.add(out_path);
@@ -135,7 +135,7 @@ public class NVDParser implements VulnerabilityParser {
             ResourceNotFoundException {
         var updates_url = new URL("https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz");
         var out_path = new File(mnt + "/nvd/nvdcve-1.1-modified.json.gz");
-        Files.createDirectories(out_path.toPath());
+        Files.createDirectories(out_path.toPath().getParent());
         downloader.fetchFile(updates_url, out_path);
         return out_path;
     }

--- a/src/test/java/eu/fasten/vulnerabilityproducer/parsers/ExtraParserTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/parsers/ExtraParserTest.java
@@ -213,7 +213,7 @@ public class ExtraParserTest {
     public void translateYAMLToVulnerability() {
         YAMLHandler.SAPVulnMapper yaml = new YAMLHandler.SAPVulnMapper();
         yaml.vulnerability_id = "CVE-TEST";
-        var note = new YAMLHandler.NoteTextMapper();
+        var note = new YAMLHandler.NoteMapper();
         note.text = "text";
         yaml.notes.add(note);
         var fixes = new YAMLHandler.FixMapper();


### PR DESCRIPTION
Fixes #61 

Fixes for parsing SAP statement files by using different notes handler.
Some fixes for still some missing directories to download/update NVD datasets.
JSON parsing fixes for exceptions due to parse errors.
