### PR TITLE
Introduce --infer option to specify PurlMapper infer logic

### DIFF
--- a/src/main/java/eu/fasten/vulnerabilityproducer/Main.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/Main.java
@@ -74,7 +74,8 @@ public class Main implements Runnable {
                           "none  : no guessing of PURLs is performed " +
                           "repos : purls are guessed using information from the repo detected " +
                           "cpes  : purls are guessed using cpe information where a mapping can be found " +
-                          "both  : use both repos and cpes to guess the PURLs of the vulnerability.")
+                          "both  : use both repos and cpes to guess the PURLs of the vulnerability.",
+            defaultValue = "both")
     String inferStrategy;
 
     public static void main(String[] args) {

--- a/src/main/java/eu/fasten/vulnerabilityproducer/Main.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/Main.java
@@ -68,6 +68,15 @@ public class Main implements Runnable {
             description = "If included, the VulnerabilityProducer will go straight to updater")
     boolean update;
 
+    @CommandLine.Option(names = {"-i", "--infer"},
+            paramLabel  = "inferStrategy",
+            description = "Infer strategy to use. " +
+                          "none  : no guessing of PURLs is performed " +
+                          "repos : purls are guessed using information from the repo detected " +
+                          "cpes  : purls are guessed using cpe information where a mapping can be found " +
+                          "both  : use both repos and cpes to guess the PURLs of the vulnerability.")
+    String inferStrategy;
+
     public static void main(String[] args) {
         final int exitCode = new CommandLine(new Main()).execute(args);
         System.exit(exitCode);
@@ -115,7 +124,13 @@ public class Main implements Runnable {
             // Starting the producer
             logger.info("Starting the producer");
             try {
-                vulnProducer.start(update);
+                if (!(inferStrategy.equals("both")  ||
+                    inferStrategy.equals("repos") ||
+                    inferStrategy.equals("cpes")  ||
+                    inferStrategy.equals("none"))) {
+                    logger.error("Infer strategy not supported.");
+                }
+                vulnProducer.start(update, inferStrategy);
             } catch (IOException e) {
                 logger.error("Could not start producer: ", e);
             }

--- a/src/main/java/eu/fasten/vulnerabilityproducer/VulnerabilityProducer.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/VulnerabilityProducer.java
@@ -75,12 +75,12 @@ public class VulnerabilityProducer {
     /**
      * Sets the connection to Mongodb instance.
      */
-    public void createParserManager() throws IOException {
+    public void createParserManager(String inferStrategy) throws IOException {
         logger.info("Creating the ParserManager");
         var client = new JavaHttpClient();
         var nc = new NitriteController(pathToMnt + "/nitrite/security.db");
         var ghToken = System.getenv("FASTEN_GHTOKEN");
-        this.parserManager = new ParserManager(client, this.mongoDatabase, nc, ghToken, pathToMnt);
+        this.parserManager = new ParserManager(client, this.mongoDatabase, nc, ghToken, pathToMnt, inferStrategy);
     }
 
     /**
@@ -97,8 +97,8 @@ public class VulnerabilityProducer {
      * Sets up the ParserManager.
      * First gets everything from parsers, then only looks for updates
      */
-    public void start(boolean updateOnly) throws IOException {
-        createParserManager();
+    public void start(boolean updateOnly, String inferStrategy) throws IOException {
+        createParserManager(inferStrategy);
 
         // Get all the information
         if (!updateOnly)

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/PatchFinder.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/PatchFinder.java
@@ -148,9 +148,7 @@ public class PatchFinder {
                 }
             }
         }
-
         vulnerability.getReferences().removeAll(patchLinks);    // removing patch_links form refs
-        vulnerability.setPatchLinks(patchLinks);                // setting patch_links in vuln_obj
     }
 
     /**

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/PurlMapper.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/PurlMapper.java
@@ -41,11 +41,16 @@ public class PurlMapper {
     public HashMap<String, String> mavenMap;    // repo_url -> purl
     public HashMap<String, String> pypiMap;     // repo_url -> purl
     public HashMap<String, String> cpeMap;      // cpe_base -> repo_url
+    public String strategy;
     private final Logger logger = LoggerFactory.getLogger(PurlMapper.class.getName());
 
-    public PurlMapper(VersionRanger versionRanger, PatchFinder patchFinder, String pathToMaps) {
+    public PurlMapper(VersionRanger versionRanger,
+                      PatchFinder patchFinder,
+                      String pathToMaps,
+                      String inferStrategy) {
         this.versionRanger = versionRanger;
         this.patchFinder   = patchFinder;
+        this.strategy      = inferStrategy;
         this.mavenMap      = loadReposMapFromMemory(pathToMaps + "repo_map_maven.json");
         this.pypiMap       = loadReposMapFromMemory(pathToMaps + "repo_map_pypi.json");
         this.cpeMap        = loadReposMapFromMemory(pathToMaps + "cpe_map_repos.json");
@@ -72,11 +77,15 @@ public class PurlMapper {
         var baseRepo = patchFinder.getBaseRepo(v);
         var patchedDate = getPatchDateVulnerability(v);
 
-        findMatchedPurl(mavenMap, v, patchedDate, baseRepo);
-        findMatchedPurl(pypiMap, v, patchedDate, baseRepo);
+        if (strategy.equals("both") || strategy.equals("repos")) {
+            findMatchedPurl(mavenMap, v, patchedDate, baseRepo);
+            findMatchedPurl(pypiMap, v, patchedDate, baseRepo);
+        }
 
-        if (v.getPurls().size() == 0 && v.getBaseCpes() != null && v.getBaseCpes().size() > 0) {
-            findPurlsFromCpes(v);
+        if (strategy.equals("both") || strategy.equals("cpes")) {
+            if (v.getPurls().size() == 0 && v.getBaseCpes() != null && v.getBaseCpes().size() > 0) {
+                findPurlsFromCpes(v);
+            }
         }
     }
 

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
@@ -66,20 +66,21 @@ public class ParserManager {
                          MongoDatabase mongoDatabase,
                          NitriteController nitriteController,
                          String ghToken,
-                         String mnt) throws IOException {
+                         String mnt,
+                         String inferStrategy) throws IOException {
         Files.createDirectories(Path.of(mnt, "trackers"));
         Files.createDirectories(Path.of(mnt, "datasets"));
         this.mnt = mnt;
         this.ghToken = ghToken;
         this.nitriteController = nitriteController;
         this.versionRanger = new VersionRanger(client, mnt + "/trackers/package_versions.json");
-        this.extraParser = new ExtraParser(client, versionRanger, mnt);
-        this.ovalParser = new OVALParser(client, versionRanger);
+        this.extraParser   = new ExtraParser(client, versionRanger, mnt);
+        this.ovalParser    = new OVALParser(client, versionRanger);
         this.ossFuzzParser = new OSSFuzzParser(mnt);
-        this.ghParser = new GHParser(client, ghToken, versionRanger, mnt + "/trackers/ghcursor.txt");
-        this.patchFinder = new PatchFinder(mongoDatabase, client, ghToken);
-        this.purlMapper = new PurlMapper(versionRanger, patchFinder, mnt + "/datasets/purl_maps/");
-        this.nvdParser = new NVDParser(new JSONParser(), client, this.purlMapper, mnt);
+        this.ghParser      = new GHParser(client, ghToken, versionRanger, mnt + "/trackers/ghcursor.txt");
+        this.patchFinder   = new PatchFinder(mongoDatabase, client, ghToken);
+        this.purlMapper    = new PurlMapper(versionRanger, patchFinder, mnt + "/datasets/purl_maps/", inferStrategy);
+        this.nvdParser     = new NVDParser(new JSONParser(), client, this.purlMapper, mnt);
     }
 
     /**

--- a/src/test/java/eu/fasten/vulnerabilityproducer/PatchFinderTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/PatchFinderTest.java
@@ -588,7 +588,7 @@ public class PatchFinderTest {
 
         assertTrue(v.getPatches().contains(patch));
         var vcsPatch = "git://github.com/mongodb/mongo@443e8974d66a3ddd2ad89f8b3f9c2ebb7d8d9500";
-        assertTrue(v.getPatchLinks().contains(vcsPatch));
+        assertTrue(v.getPatches().iterator().next().getPatchUrl().equals(vcsPatch));
     }
 
     @Test

--- a/src/test/java/eu/fasten/vulnerabilityproducer/mappers/PurlMapperTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/mappers/PurlMapperTest.java
@@ -38,7 +38,7 @@ public class PurlMapperTest {
 
     VersionRanger vrMock = Mockito.mock(VersionRanger.class);
     PatchFinder pfMock = Mockito.mock(PatchFinder.class);
-    PurlMapper purlMapper = new PurlMapper(vrMock, pfMock, "./src/test/resources/purl_maps/");
+    PurlMapper purlMapper = new PurlMapper(vrMock, pfMock, "./src/test/resources/purl_maps/", "both");
 
     @Test
     public void getBasePurlTest() {

--- a/src/test/java/eu/fasten/vulnerabilityproducer/mappers/PurlMapperTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/mappers/PurlMapperTest.java
@@ -103,4 +103,113 @@ public class PurlMapperTest {
         purlMapper.inferPurls(v);
         assertTrue(v.getPurls().contains("pkg:maven/org.apache.tomcat/tomcat@10.0"));
     }
+
+    @Test
+    public void testStrategyNone() {
+        purlMapper.strategy = "none";
+
+        var v = new Vulnerability("TEST-1");
+        v.setBaseCpes(new HashSet<>(Collections.singletonList("cpe:2.3:a:google:guava")));
+        v.addPatchLink("https//github.com/python/django/commit/5326bi6b5u53b1u5ob1b5i265");
+
+        // inject CPE information
+        var cpe_versions = new HashMap<String, List<String>>();
+        cpe_versions.put("cpe:2.3:a:google:guava",  Arrays.asList("1.0", "2.0"));
+        when(vrMock.getCPEVersions(v.getId())).thenReturn(cpe_versions);
+
+        // inject PURL information
+        purlMapper.pypiMap.put("https://github.com/python/django", "pkg:pypi/django");
+        var versions = new ArrayList<String>(); versions.add("pkg:pypi/django@1.9");
+        v.addPatchLink("https//github.com/python/django/commit/5326bi6b5u53b1u5ob1b5i265");
+        v.addPatch(new Patch("oof.py", null, null, null, "2018-05-30"));
+
+        when(vrMock.getPurlsBeforeDate(Mockito.anyString(), Mockito.any())).thenReturn(versions);
+        when(pfMock.getBaseRepo(v)).thenReturn("https://github.com/python/django");
+
+        purlMapper.inferPurls(v);
+        assertEquals(0, v.getPurls().size());
+    }
+
+    @Test
+    public void testStrategyRepos() {
+        purlMapper.strategy = "repos";
+
+        var v = new Vulnerability("TEST-1");
+        v.setBaseCpes(new HashSet<>(Collections.singletonList("cpe:2.3:a:google:guava")));
+        v.addPatchLink("https//github.com/python/django/commit/5326bi6b5u53b1u5ob1b5i265");
+
+        // inject CPE information
+        var cpe_versions = new HashMap<String, List<String>>();
+        cpe_versions.put("cpe:2.3:a:google:guava",  Arrays.asList("1.0", "2.0"));
+        when(vrMock.getCPEVersions(v.getId())).thenReturn(cpe_versions);
+
+        // inject PURL information
+        purlMapper.pypiMap.put("https://github.com/python/django", "pkg:pypi/django");
+        var versions = new ArrayList<String>(); versions.add("pkg:pypi/django@1.9");
+        v.addPatchLink("https//github.com/python/django/commit/5326bi6b5u53b1u5ob1b5i265");
+        v.addPatch(new Patch("oof.py", null, null, null, "2018-05-30"));
+
+        when(vrMock.getPurlsBeforeDate(Mockito.anyString(), Mockito.any())).thenReturn(versions);
+        when(pfMock.getBaseRepo(v)).thenReturn("https://github.com/python/django");
+
+        purlMapper.inferPurls(v);
+
+        assertTrue(v.getPurls().contains("pkg:pypi/django@1.9"));
+    }
+
+    @Test
+    public void testStrategyCpes() {
+        purlMapper.strategy = "cpes";
+
+        var v = new Vulnerability("TEST-1");
+        v.setBaseCpes(new HashSet<>(Collections.singletonList("cpe:2.3:a:google:guava")));
+        v.addPatchLink("https//github.com/python/django/commit/5326bi6b5u53b1u5ob1b5i265");
+
+        // inject CPE information
+        var cpe_versions = new HashMap<String, List<String>>();
+        cpe_versions.put("cpe:2.3:a:google:guava",  Arrays.asList("1.0", "2.0"));
+        when(vrMock.getCPEVersions(v.getId())).thenReturn(cpe_versions);
+
+        // inject PURL information
+        purlMapper.pypiMap.put("https://github.com/python/django", "pkg:pypi/django");
+        var versions = new ArrayList<String>(); versions.add("pkg:pypi/django@1.9");
+        v.addPatchLink("https//github.com/python/django/commit/5326bi6b5u53b1u5ob1b5i265");
+        v.addPatch(new Patch("oof.py", null, null, null, "2018-05-30"));
+
+        when(vrMock.getPurlsBeforeDate(Mockito.anyString(), Mockito.any())).thenReturn(versions);
+        when(pfMock.getBaseRepo(v)).thenReturn("https://github.com/python/django");
+
+        purlMapper.inferPurls(v);
+
+        assertTrue(v.getPurls().contains("pkg:maven/org.google.guava/guava@1.0"));
+        assertTrue(v.getPurls().contains("pkg:maven/org.google.guava/guava@2.0"));
+    }
+
+    @Test
+    public void testStrategyBoth() {
+        purlMapper.strategy = "both";
+
+        var v = new Vulnerability("TEST-1");
+        v.setBaseCpes(new HashSet<>(Collections.singletonList("cpe:2.3:a:google:guava")));
+        v.addPatchLink("https//github.com/python/django/commit/5326bi6b5u53b1u5ob1b5i265");
+
+        // inject CPE information
+        var cpe_versions = new HashMap<String, List<String>>();
+        cpe_versions.put("cpe:2.3:a:google:guava",  Arrays.asList("1.0", "2.0"));
+        when(vrMock.getCPEVersions(v.getId())).thenReturn(cpe_versions);
+
+        // inject PURL information
+        purlMapper.pypiMap.put("https://github.com/python/django", "pkg:pypi/django");
+        var versions = new ArrayList<String>(); versions.add("pkg:pypi/django@1.9");
+        v.addPatchLink("https//github.com/python/django/commit/5326bi6b5u53b1u5ob1b5i265");
+        v.addPatch(new Patch("oof.py", null, null, null, "2018-05-30"));
+
+        when(vrMock.getPurlsBeforeDate(Mockito.anyString(), Mockito.any())).thenReturn(versions);
+        when(pfMock.getBaseRepo(v)).thenReturn("https://github.com/python/django");
+
+        purlMapper.inferPurls(v);
+
+        // in the case where both contain mappings, priority is given to the repos strategy
+        assertTrue(v.getPurls().contains("pkg:pypi/django@1.9"));
+    }
 }

--- a/src/test/java/eu/fasten/vulnerabilityproducer/parsers/ParserManagerTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/parsers/ParserManagerTest.java
@@ -45,7 +45,7 @@ public class ParserManagerTest {
     NitriteController ncMOck = Mockito.mock(NitriteController.class);
     KafkaProducer<String, String> kpMock = Mockito.mock(KafkaProducer.class);
     final String topic = "testing";
-    ParserManager pm = new ParserManager(client, dbMock, ncMOck, "mocktoken", VulnerabilityProducerTest.testmnt);
+    ParserManager pm = new ParserManager(client, dbMock, ncMOck, "mocktoken", VulnerabilityProducerTest.testmnt, "both");
     GHParser ghParserMock = Mockito.mock(GHParser.class);
     NVDParser nvdParserMock = Mockito.mock(NVDParser.class);
     OVALParser ovalParserMock = Mockito.mock(OVALParser.class);


### PR DESCRIPTION
Three different inferring strategies can be configured for the `PurlMapper` to use when trying to guess the package-URL information of the vulnerability. Default is `both`. See #70 for more details.