### PR TITLE
Use a voting pool to infer PURLs

### DIFF
--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/MutablePair.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/MutablePair.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.fasten.vulnerabilityproducer.utils.mappers;
+
+public class MutablePair {
+    public String key;
+    public Integer value;
+
+    public MutablePair(String key, Integer value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public Integer getValue() {
+        return value;
+    }
+
+    public void setValue(Integer value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/Pool.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/Pool.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.fasten.vulnerabilityproducer.utils.mappers;
+
+import java.util.*;
+
+public class Pool {
+    private HashMap<String, List<MutablePair>> mappings;
+
+    /**
+     * Constructor for a Pool.
+     * @param maps - mappings extracted from the metadata of each ecosystem.
+     * @param initialWeight - initial weight to give to those mappings.
+     */
+    public Pool(List<HashMap<String, String>> maps, int initialWeight) {
+        var mappings = new HashMap<String, List<MutablePair>>();
+        maps.forEach(map -> map.forEach((k, v) -> {
+            var pairs = mappings.getOrDefault(k, new ArrayList<>());
+            pairs.add(new MutablePair(v, initialWeight));
+            mappings.put(k, pairs);
+        }));
+        this.mappings = mappings;
+    }
+
+    public HashMap<String, List<MutablePair>> getMappings() {
+        return mappings;
+    }
+
+    /**
+     * Inserts a new vote into the pool. If no correspondence is already stored, a new one is added.
+     * Otherwise, the count is increased by 1 for the found match.
+     * @param key - in our case is either the repo_url or the cpe.
+     * @param value - the purl found to be corresponding to it.
+     */
+    public void insertVote(String key, String value) { // key = repo, value = purl
+        if (mappings.containsKey(key)) {
+            var pairs = mappings.get(key);
+            var found = false;
+            for (MutablePair pair : pairs) {
+                if (pair.key.equals(value)) {
+                    pair.value += 1;
+                    found = true;
+                }
+            }
+            if (!found) {
+                pairs.add(new MutablePair(value, 1));
+            }
+        } else {
+            var pairs = new ArrayList<MutablePair>(); pairs.add(new MutablePair(value, 1));
+            mappings.put(key, pairs);
+        }
+    }
+
+    /**
+     * Finds the most voted match with the given key.
+     * @param key - in our case is either the repo_url or the cpe.
+     * @return the value in the pair with the most votes.
+     */
+    public String getMostVoted(String key) {
+        if (!mappings.containsKey(key)) return null;
+        var candidates = mappings.get(key);
+        // extract the most voted. in the case of a tie, return the last one you stored
+        String mostVoted = null;
+        var maxVotes = 0;
+        for (MutablePair candidate : candidates) {
+            if (candidate.value > maxVotes) mostVoted = candidate.key;
+        }
+        return mostVoted;
+    }
+}

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/PurlMapper.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/PurlMapper.java
@@ -43,8 +43,13 @@ public class PurlMapper {
     public HashMap<String, String> pypiMap;      // repo_url -> purl
     public HashMap<String, String> cpeMap;       // cpe_base -> repo_url
     public HashMap<String, String> debianCpeMap; // cpe_base -> purl
-    public HashMap<String, String> cpe2purl;     // cpe_base -> purl
+
+    public Pool cpe2purl;     // cpe_base -> purl
+    public Pool repo2purl;    // repo_url -> purl
+    public int INITIAL_WEIGHT_REPO = 10;
+    public int INITIAL_WEIGHT_CPE  = 10;
     public String strategy;
+
     private final Logger logger = LoggerFactory.getLogger(PurlMapper.class.getName());
 
     public PurlMapper(VersionRanger versionRanger,
@@ -59,7 +64,44 @@ public class PurlMapper {
         this.pypiMap       = loadReposMapFromMemory(pathToMaps + "repo_map_pypi.json");
         this.cpeMap        = loadReposMapFromMemory(pathToMaps + "cpe_map_repos.json");
         this.debianCpeMap  = loadDebianCPEMap(client);
-        this.cpe2purl      = createCpe2PurlMap(cpeMap, mavenMap, pypiMap, debianCpeMap);
+
+        this.cpe2purl      = createCpe2PurlPool(cpeMap, mavenMap, pypiMap, debianCpeMap);
+        this.repo2purl     = createRepo2PurlPool(mavenMap, pypiMap);
+    }
+
+    /**
+     * Constructor for the repo2purl voting pool.
+     * @param mavenMap - maven repo_url -> purl map.
+     * @param pypiMap  - pypi  repo_url -> purl map.
+     * @return a voting pool that joins the two maps.
+     */
+    private Pool createRepo2PurlPool(HashMap<String, String> mavenMap,
+                                     HashMap<String, String> pypiMap) {
+        var maps = Arrays.asList(mavenMap, pypiMap);
+        var pool = new Pool(maps, INITIAL_WEIGHT_REPO);
+        return pool;
+    }
+
+    /**
+     * Constructor for the cpe2purl voting pool.
+     * @param cpeMap - cpe_base -> repo_url map
+     * @param mavenMap - repo_url -> purl map
+     * @param pypiMap -  repo_url -> purl map
+     * @param debianCpeMap - base_cpe -> purl
+     * @return a voting pool with cpe_base -> purl correspondence.
+     */
+    private Pool createCpe2PurlPool(HashMap<String, String> cpeMap,
+                                    HashMap<String, String> mavenMap,
+                                    HashMap<String, String> pypiMap,
+                                    HashMap<String, String> debianCpeMap) {
+        cpeMap.keySet().forEach(cpe -> {
+            var repo = cpeMap.get(cpe);
+            if (mavenMap.containsKey(repo)) debianCpeMap.put(cpe, mavenMap.get(repo));
+            if (pypiMap.containsKey(repo))  debianCpeMap.put(cpe, pypiMap.get(repo));
+        });
+        var maps = Arrays.asList(debianCpeMap);
+        var pool = new Pool(maps, INITIAL_WEIGHT_CPE);
+        return pool;
     }
 
     /**
@@ -117,26 +159,6 @@ public class PurlMapper {
     }
 
     /**
-     * Initiates the cpe2purl map by intersecting the repos found corresponding to CPEs with the ecosystem mappings found.
-     * @param cpeMap    - maps each CPE to the repo_url, where found
-     * @param mavenMap  - maps each Maven PURL to the repo_url, where found
-     * @param pypiMap   - maps each PyPI PURL to the repo_url, where found
-     * @return - map between CPE and its repo_url, if an intersection if found
-     */
-    private HashMap<String, String> createCpe2PurlMap(HashMap<String, String> cpeMap,
-                                                      HashMap<String, String> mavenMap,
-                                                      HashMap<String, String> pypiMap,
-                                                      HashMap<String, String> debianCpeMap) {
-        var cpe2purl  = debianCpeMap;       // initialize to debian CPE list
-        cpeMap.keySet().forEach(cpe -> {
-            var repo = cpeMap.get(cpe);
-            if (mavenMap.containsKey(repo)) cpe2purl.put(cpe, mavenMap.get(repo));
-            if (pypiMap.containsKey(repo))  cpe2purl.put(cpe, pypiMap.get(repo));
-        });
-        return cpe2purl;
-    }
-
-    /**
      * Given a vulnerability, it manipulates it to either store or infer mappings.
      * @param v - Vulnerability object
      */
@@ -170,81 +192,53 @@ public class PurlMapper {
     public void repo2PurlInfer(Vulnerability v,
                                DateTime patchedDate,
                                String baseRepo,
-                               String cpe) {
-        findPURLFromRepoMap(mavenMap, v, patchedDate, baseRepo, cpe);
-        findPURLFromRepoMap(pypiMap,  v, patchedDate, baseRepo, cpe);
+                               String baseCPE) {
+        if (baseRepo == null)   return;
+        var basePurl = getPurlBase(v);
+
+        if (basePurl != null) {
+            repo2purl.insertVote(baseRepo, basePurl);
+        }
+
+        // infer the package-info
+        if (basePurl == null) {
+            basePurl = repo2purl.getMostVoted(baseRepo);
+            if (baseCPE != null) {
+                var versions = versionRanger.getCPEVersions(v.getId()).get(baseCPE);
+                for (String version : versions) {
+                    v.addPurl(basePurl + "@" + version);
+                }
+            } else if (patchedDate != null && v.getPurls().size() == 0) {
+                var inferredPurls = versionRanger.getPurlsBeforeDate(basePurl, patchedDate);
+                inferredPurls.forEach(v::addPurl);
+            }
+        }
+
+        // infer the first patched version
+        if (v.getFirstPatchedPurls().size() == 0 && patchedDate != null) {
+            var firstPatchedPurl = versionRanger.getFirstPurlAfterDate(basePurl, patchedDate);
+            if (firstPatchedPurl != null) v.getFirstPatchedPurls().add(firstPatchedPurl);
+        }
     }
 
     /**
      * CPE2PURL strategy implementation.
      * @param v - Vulnerability Object to infer/store information about.
-     * @param cpe - base CPE of the vulnerability. Provided by NVD
+     * @param baseCPE - base CPE of the vulnerability. Provided by NVD
      */
     public void cpe2PurlInfer(Vulnerability v,
-                              String cpe) {
-        // use cpe2purl only if repo2purl failed
-        if (v.getPurls().size() == 0) {
-            if (cpe2purl.containsKey(cpe)) {
-                var purl = cpe2purl.get(cpe);
-                var versions = versionRanger.getCPEVersions(v.getId()).get(cpe);
-                versions.forEach(version -> v.addPurl(purl + "@" + version));
-            }
+                              String baseCPE) {
+        var basePurl = getPurlBase(v);
 
-            // special-treatment for Apache projects
-            if (cpe.startsWith("cpe:2.3:a:apache:") && v.getPurls().size() == 0) {
-                var project = cpe.substring("cpe:2.3:a:apache:".length());
-                var basePurl = "pkg:maven/org.apache." + project + "/" + project;
-                var versions = versionRanger.getCPEVersions(v.getId()).get(cpe);
-                if (Objects.nonNull(versions)) {
-                    versions.forEach(version -> v.addPurl(basePurl + "@" + version));
-                }
-                else {
-                    logger.warn("Could not find versions for CPE: " + cpe);
-                }
-
-            }
-        } else {
-            var purlBase = getPurlBase(v);
-            // only put match if not present
-            if (!cpe2purl.containsKey(cpe)) cpe2purl.put(cpe, purlBase);
-        }
-    }
-
-    /**
-     * Helper method to inject stuff in the purl_maps and infer.
-     * @param purlMap - map of the purls
-     * @param v - Vulnerability Object
-     * @param patchedDate - date of the patch
-     * @param baseRepo - baseRepo extracted from the vulnerability
-     * @param baseCPE  - baseCPE extracted from NVD statement of the vulnerability.
-     */
-    public void findPURLFromRepoMap(HashMap<String, String> purlMap,
-                                Vulnerability v,
-                                DateTime patchedDate,
-                                String baseRepo, String baseCPE) {
-        if (baseRepo == null)   return;
-
-        if (v.getPurls().size() > 0) {
-            if (!purlMap.containsKey(baseRepo)) purlMap.put(baseRepo, getPurlBase(v));
+        if (basePurl != null) {
+            cpe2purl.insertVote(baseCPE, basePurl);
         }
 
-        var basePurl = purlMap.get(baseRepo);
-        if (basePurl == null)    return;
-        if (v.getPurls().size() == 0 && baseCPE != null) {
+        if (basePurl == null) {
+            var purl = cpe2purl.getMostVoted(baseCPE);
             var versions = versionRanger.getCPEVersions(v.getId()).get(baseCPE);
-            if (versions != null) {
-                versions.forEach(version -> v.addPurl(basePurl + "@" + version));
-            }
-        }
-
-        if (v.getPurls().size() == 0 && patchedDate != null) {
-            var inferredPurls = versionRanger.getPurlsBeforeDate(basePurl, patchedDate);
-            inferredPurls.forEach(v::addPurl);
-        }
-
-        if (v.getFirstPatchedPurls().size() == 0 && patchedDate != null) {
-            var firstPatchedPurl = versionRanger.getFirstPurlAfterDate(basePurl, patchedDate);
-            if (firstPatchedPurl != null) v.getFirstPatchedPurls().add(firstPatchedPurl);
+            if (versions == null)   return;
+            versions.forEach(version -> v.addPurl(purl + "@" + version));
         }
     }
 
@@ -286,10 +280,9 @@ public class PurlMapper {
      * @return String
      */
     public String getPurlBase(Vulnerability v) {
-        assert v.getPurls().size() > 0;
+        if (v.getPurls().size() == 0) return null;
         var firstPurl = v.getPurls().iterator().next();
         var base = firstPurl.split("@")[0];
-        assert base != null;
         return base;
     }
 }

--- a/src/test/java/eu/fasten/vulnerabilityproducer/mappers/PoolTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/mappers/PoolTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.fasten.vulnerabilityproducer.mappers;
+
+import eu.fasten.vulnerabilityproducer.utils.mappers.*;
+import org.junit.jupiter.api.*;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PoolTest {
+
+    HashMap<String, String> mavenMap = new HashMap<>();
+    HashMap<String, String> pypiMap = new HashMap<>();
+    int INITIAL_WEIGHT = 10;
+
+    Pool pool;
+
+    @BeforeEach
+    public void populateMaps() {
+        mavenMap.put("https://github.com/mockito/mockito", "pkg:maven/org.mockito/mockito-core");
+        mavenMap.put("https://github.com/tensorflow/tensorflow", "pkg:maven/org.tensorflow/tensorflow");
+
+        pypiMap.put("https://github.com/pallets/flask", "pkg:pypi/flask");
+        pypiMap.put("https://github.com/tensorflow/tensorflow", "pkg:pypi/tensorflow");
+
+        var maps = Arrays.asList(mavenMap, pypiMap);
+        pool = new Pool(maps, INITIAL_WEIGHT);
+    }
+
+    @Test
+    public void testConstructor() {
+        var keyMaven  = "https://github.com/mockito/mockito";
+        var keyPypi   = "https://github.com/pallets/flask";
+        var keyShared = "https://github.com/tensorflow/tensorflow";
+
+        assertTrue(pool.getMappings().containsKey(keyMaven));
+        assertTrue(pool.getMappings().containsKey(keyPypi));
+        assertTrue(pool.getMappings().containsKey(keyShared));
+
+        assertEquals("pkg:maven/org.mockito/mockito-core", pool.getMappings().get(keyMaven).get(0).getKey());
+        assertEquals("pkg:pypi/flask", pool.getMappings().get(keyPypi).get(0).getKey());
+        assertEquals("pkg:maven/org.tensorflow/tensorflow", pool.getMappings().get(keyShared).get(0).getKey());
+        assertEquals("pkg:pypi/tensorflow", pool.getMappings().get(keyShared).get(1).getKey());
+
+
+        assertEquals(INITIAL_WEIGHT, pool.getMappings().get(keyMaven).get(0).getValue());
+        assertEquals(INITIAL_WEIGHT, pool.getMappings().get(keyPypi).get(0).getValue());
+        assertEquals(INITIAL_WEIGHT, pool.getMappings().get(keyShared).get(0).getValue());
+        assertEquals(INITIAL_WEIGHT, pool.getMappings().get(keyShared).get(1).getValue());
+    }
+
+    @Test
+    public void testInsertVote() {
+        // new_key - new_value --> create new mapping
+        var key = "https://github.com/apache/tomcat";
+        var value = "pkg:maven/org.apache.tomcat/tomcat-core";
+        pool.insertVote(key, value);
+        assertTrue(pool.getMappings().containsKey(key));
+        assertEquals(value, pool.getMappings().get(key).get(0).getKey());
+        assertEquals(1, pool.getMappings().get(key).get(0).getValue());
+
+        // old_key - new_value --> create new pair with count 1
+        var oldKey = "https://github.com/pallets/flask";
+        var newValue = "pkg:pypi/fake_flask";
+        pool.insertVote(oldKey, newValue);
+        assertEquals(newValue, pool.getMappings().get(oldKey).get(1).getKey());
+        assertEquals(1, pool.getMappings().get(oldKey).get(1).getValue());
+
+        // old_key - old_value --> increase count by 1
+        var oldValue = "pkg:pypi/flask";
+        pool.insertVote(oldKey, oldValue);
+        assertEquals(INITIAL_WEIGHT + 1, pool.getMappings().get(oldKey).get(0).getValue());
+    }
+
+    @Test
+    public void testGetMostVoted() {
+        var matchGood = pool.getMostVoted("https://github.com/mockito/mockito");
+        assertEquals("pkg:maven/org.mockito/mockito-core", matchGood);
+
+        pool.insertVote("https://github.com/tensorflow/tensorflow", "pkg:pypi/tensorflow");
+        var matchShared = pool.getMostVoted("https://github.com/tensorflow/tensorflow");
+        assertEquals("pkg:pypi/tensorflow", matchShared);
+
+        pool.insertVote("https://github.com/owner/project", "pkg:pypi/wrong_project");
+        pool.insertVote("https://github.com/owner/project", "pkg:pypi/project");
+        pool.insertVote("https://github.com/owner/project", "pkg:pypi/project");
+        var matchOverthrow = pool.getMostVoted("https://github.com/owner/project");
+        assertEquals("pkg:pypi/project", matchOverthrow);
+    }
+}

--- a/src/test/java/eu/fasten/vulnerabilityproducer/mappers/PurlMapperTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/mappers/PurlMapperTest.java
@@ -76,23 +76,23 @@ public class PurlMapperTest {
 
     @Test
     public void creationCPE2PURLMap() {
-        assertTrue(purlMapper.cpe2purl.containsKey("cpe:2.3:a:google:guava"));
-        assertEquals("pkg:maven/org.google.guava/guava", purlMapper.cpe2purl.get("cpe:2.3:a:google:guava"));
+        assertTrue(purlMapper.cpe2purl.getMappings().containsKey("cpe:2.3:a:google:guava"));
+        assertEquals("pkg:maven/org.google.guava/guava", purlMapper.cpe2purl.getMostVoted("cpe:2.3:a:google:guava"));
     }
 
     @Test
     public void importDebianCPE() {
-        assertTrue(purlMapper.cpe2purl.containsKey("cpe:2.3:a:gnu:a2ps"));
-        assertEquals("pkg:deb/debian/a2ps", purlMapper.cpe2purl.get("cpe:2.3:a:gnu:a2ps"));
+        assertTrue(purlMapper.cpe2purl.getMappings().containsKey("cpe:2.3:a:gnu:a2ps"));
+        assertEquals("pkg:deb/debian/a2ps", purlMapper.cpe2purl.getMostVoted("cpe:2.3:a:gnu:a2ps"));
 
-        assertTrue(purlMapper.cpe2purl.containsKey("cpe:2.3:a:asterisk:opensource"));
-        assertEquals("pkg:deb/debian/asterisk", purlMapper.cpe2purl.get("cpe:2.3:a:asterisk:opensource"));
+        assertTrue(purlMapper.cpe2purl.getMappings().containsKey("cpe:2.3:a:asterisk:opensource"));
+        assertEquals("pkg:deb/debian/asterisk", purlMapper.cpe2purl.getMostVoted("cpe:2.3:a:asterisk:opensource"));
     }
 
     // repo2purl
     @Test
     public void inferPurlPyPIMap() {
-        purlMapper.pypiMap.put("https://github.com/python/django", "pkg:pypi/django");
+        purlMapper.repo2purl.insertVote("https://github.com/python/django", "pkg:pypi/django");
         var versions = new ArrayList<String>(); versions.add("pkg:pypi/django@1.9");
         var v = new Vulnerability();
         v.addPatchLink("https//github.com/python/django/commit/5326bi6b5u53b1u5ob1b5i265");
@@ -107,7 +107,7 @@ public class PurlMapperTest {
 
     @Test
     public void inferPurlMavenMap() {
-        purlMapper.mavenMap.put("https://github.com/apache/hive", "pkg:mvn/org.apache/hive");
+        purlMapper.repo2purl.insertVote("https://github.com/apache/hive", "pkg:mvn/org.apache/hive");
         var versions = new ArrayList<String>(); versions.add("pkg:maven/org.apache/hive@0.1");
         var v = new Vulnerability();
         v.addPatchLink("https//github.com/apache/hive/commit/5326bi6b5u53b1u5ob1b5i265");
@@ -121,19 +121,6 @@ public class PurlMapperTest {
     }
 
     @Test
-    public void inferPurlSpecialApacheCase() {
-        var v = new Vulnerability("TEST-1");
-        v.setBaseCpe("cpe:2.3:a:apache:tomcat");
-
-        var cpe_versions = new HashMap<String, List<String>>();
-        cpe_versions.put("cpe:2.3:a:apache:tomcat",  Arrays.asList("10.0"));
-        when(vrMock.getCPEVersions(v.getId())).thenReturn(cpe_versions);
-
-        purlMapper.inferPurls(v);
-        assertTrue(v.getPurls().contains("pkg:maven/org.apache.tomcat/tomcat@10.0"));
-    }
-
-    @Test
     public void storeRepo2PurlRepoInfo() {
         var v = new Vulnerability();
         v.addPurl("pkg:pypi/django@1.9");
@@ -142,13 +129,13 @@ public class PurlMapperTest {
         when(pfMock.getBaseRepo(v)).thenReturn("https://github.com/python/django");
 
         purlMapper.inferPurls(v);
-        assertEquals("pkg:pypi/django", purlMapper.pypiMap.get("https://github.com/python/django"));
+        assertEquals("pkg:pypi/django", purlMapper.repo2purl.getMostVoted("https://github.com/python/django"));
     }
 
     // cpe2purl
     @Test
     public void inferPurlCpe2Purl() {
-        purlMapper.cpe2purl.put("cpe:2.3:a:apache:hive", "pkg:maven/org.apache.hive/hive");
+        purlMapper.cpe2purl.insertVote("cpe:2.3:a:apache:hive", "pkg:maven/org.apache.hive/hive");
 
         var v = new Vulnerability("CVE-TEST");
         v.setBaseCpe("cpe:2.3:a:apache:hive");
@@ -169,8 +156,8 @@ public class PurlMapperTest {
 
         purlMapper.inferPurls(v);
 
-        assertTrue(purlMapper.cpe2purl.containsKey("cpe:2.3:a:foo:foo"));
-        assertEquals("pkg:pypi/foo", purlMapper.cpe2purl.get("cpe:2.3:a:foo:foo"));
+        assertTrue(purlMapper.cpe2purl.getMappings().containsKey("cpe:2.3:a:foo:foo"));
+        assertEquals("pkg:pypi/foo", purlMapper.cpe2purl.getMostVoted("cpe:2.3:a:foo:foo"));
     }
 
     @Test
@@ -183,11 +170,11 @@ public class PurlMapperTest {
 
         purlMapper.inferPurls(v);
 
-        assertTrue(purlMapper.cpe2purl.containsKey("cpe:2.3:a:foo:foo"));
-        assertEquals("pkg:pypi/foo", purlMapper.cpe2purl.get("cpe:2.3:a:foo:foo"));
+        assertTrue(purlMapper.cpe2purl.getMappings().containsKey("cpe:2.3:a:foo:foo"));
+        assertEquals("pkg:pypi/foo", purlMapper.cpe2purl.getMostVoted("cpe:2.3:a:foo:foo"));
 
-        assertTrue(purlMapper.pypiMap.containsKey("https://github.com/foo/foo"));
-        assertEquals("pkg:pypi/foo", purlMapper.pypiMap.get("https://github.com/foo/foo"));
+        assertTrue(purlMapper.repo2purl.getMappings().containsKey("https://github.com/foo/foo"));
+        assertEquals("pkg:pypi/foo", purlMapper.repo2purl.getMostVoted("https://github.com/foo/foo"));
     }
 
     @Test
@@ -206,7 +193,7 @@ public class PurlMapperTest {
         when(pfMock.getBaseRepo(v)).thenReturn("https://github.com/python/django");
 
         // inject cpe2purl information
-        purlMapper.cpe2purl.put("cpe:2.3:a:google:guava", "pkg:maven/org.google/guava");
+        purlMapper.cpe2purl.insertVote("cpe:2.3:a:google:guava", "pkg:maven/org.google/guava");
 
         purlMapper.inferPurls(v);
         assertEquals(0, v.getPurls().size());
@@ -217,18 +204,17 @@ public class PurlMapperTest {
         purlMapper.strategy = "repo2purl";
 
         var v = new Vulnerability("TEST-1");
-        v.setBaseCpe("cpe:2.3:a:google:guava");
         v.addPatchLink("https//github.com/python/django/commit/5326bi6b5u53b1u5ob1b5i265");
         v.setPublishedDate("2018-05-30");
 
         // inject repo2purl information
-        purlMapper.pypiMap.put("https://github.com/python/django", "pkg:pypi/django");
+        purlMapper.repo2purl.insertVote("https://github.com/python/django", "pkg:pypi/django");
         var versions = new ArrayList<String>(); versions.add("pkg:pypi/django@1.9");
         when(vrMock.getPurlsBeforeDate(Mockito.anyString(), Mockito.any())).thenReturn(versions);
         when(pfMock.getBaseRepo(v)).thenReturn("https://github.com/python/django");
 
         // inject cpe2purl information
-        purlMapper.cpe2purl.put("cpe:2.3:a:google:guava", "pkg:maven/org.google/guava");
+        purlMapper.cpe2purl.insertVote("cpe:2.3:a:google:guava", "pkg:maven/org.google/guava");
 
         purlMapper.inferPurls(v);
 
@@ -245,10 +231,10 @@ public class PurlMapperTest {
         v.setPublishedDate("2018-05-30");
 
         // inject repo2purl information
-        purlMapper.pypiMap.put("https://github.com/python/django", "pkg:pypi/django");
+        purlMapper.repo2purl.insertVote("https://github.com/python/django", "pkg:pypi/django");
 
         // inject cpe2purl information
-        purlMapper.cpe2purl.put("cpe:2.3:a:google:guava", "pkg:maven/org.google.guava/guava");
+        purlMapper.cpe2purl.insertVote("cpe:2.3:a:google:guava", "pkg:maven/org.google.guava/guava");
         var versions = new HashMap<String, List<String>>();
         versions.put("cpe:2.3:a:google:guava", Collections.singletonList("1.0"));
         when(vrMock.getCPEVersions(Mockito.anyString())).thenReturn(versions);
@@ -268,13 +254,15 @@ public class PurlMapperTest {
         v.setPublishedDate("2018-05-30");
 
         // inject repo2purl information
-        purlMapper.pypiMap.put("https://github.com/python/django", "pkg:pypi/django");
-        var versions = new ArrayList<String>(); versions.add("pkg:pypi/django@1.9");
-        when(vrMock.getPurlsBeforeDate(Mockito.anyString(), Mockito.any())).thenReturn(versions);
+        purlMapper.repo2purl.insertVote("https://github.com/python/django", "pkg:pypi/django");
+        var versions = new HashMap<String, List<String>>();
+        versions.put("cpe:2.3:a:google:guava", Collections.singletonList("1.9"));
+        when(vrMock.getCPEVersions(Mockito.anyString())).thenReturn(versions);
+
         when(pfMock.getBaseRepo(v)).thenReturn("https://github.com/python/django");
 
         // inject cpe2purl information
-        purlMapper.cpe2purl.put("cpe:2.3:a:google:guava", "pkg:maven/org.google/guava");
+        purlMapper.cpe2purl.insertVote("cpe:2.3:a:google:guava", "pkg:maven/org.google/guava");
 
         purlMapper.inferPurls(v);
 


### PR DESCRIPTION
Using a voting pool allows us to "validate" the mappings that we store.
Currently, the mappings used are immutable. This means that if a wrong mapping is stored, it would pollute the entire inference. 

Closes #84