### PR TITLE
Keep purls as linked hash set to maintain ordering but preventing duplicates

### DIFF
--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/Vulnerability.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/Vulnerability.java
@@ -23,16 +23,15 @@ import com.google.gson.annotations.SerializedName;
 import eu.fasten.vulnerabilityproducer.utils.mappers.Severity;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 public class Vulnerability implements Serializable, Comparable<Vulnerability> {
 
     private String id;
-    private List<String> purls;
+    private LinkedHashSet<String> purls;
     @SerializedName(value = "base_cpe")
     private String baseCpe;
     @SerializedName(value = "first_patched_purls")
@@ -62,7 +61,7 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
      * Empty Constructor for Serialization
      */
     public Vulnerability() {
-        this.purls = new ArrayList<>();
+        this.purls = new LinkedHashSet<>();
         this.firstPatchedPurls = new HashSet<>();
         this.references = new HashSet<>();
         this.patches = new HashSet<>();
@@ -77,7 +76,7 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
      */
     public Vulnerability(String id) {
         this.id = id;
-        this.purls = new ArrayList<>();
+        this.purls = new LinkedHashSet<>();
         this.firstPatchedPurls = new HashSet<>();
         this.references = new HashSet<>();
         this.patches = new HashSet<>();
@@ -186,17 +185,19 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
     }
 
     public void addPurl(String purl) {
-        if(!this.purls.contains(purl)) {
-            this.purls.add(purl);
-        }
+        this.purls.add(purl);
     }
 
-    public List<String> getPurls() {
+    public LinkedHashSet<String> getPurls() {
         return purls;
     }
 
     public HashSet<String> getFirstPatchedPurls() {
         return firstPatchedPurls;
+    }
+
+    public void addFirstPatchedPurl(String purl) {
+        firstPatchedPurls.add(purl);
     }
 
     public Severity getSeverity() {
@@ -229,11 +230,11 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
         this.id = id;
     }
 
-    public void setPurls(List<String> purls) {
-        this.purls = purls.stream().distinct().collect(Collectors.toList());
+    public void setPurls(LinkedHashSet<String> purls) {
+        this.purls = purls;
     }
 
-    public void setFirstPatchedPurl(HashSet<String> firstPatchedPurls) {
+    public void setFirstPatchedPurls(HashSet<String> firstPatchedPurls) {
         this.firstPatchedPurls = firstPatchedPurls;
     }
 
@@ -281,6 +282,7 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
      */
     public void merge(Vulnerability v2) {
         assert this.getId().equals(v2.getId());
+
         this.getPurls().addAll(v2.getPurls());
         this.getFirstPatchedPurls().addAll(v2.getFirstPatchedPurls());
         this.getReferences().addAll(v2.getReferences());

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/PurlMapper.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/PurlMapper.java
@@ -217,7 +217,7 @@ public class PurlMapper {
         // infer the first patched version
         if (v.getFirstPatchedPurls().size() == 0 && patchedDate != null) {
             var firstPatchedPurl = versionRanger.getFirstPurlAfterDate(basePurl, patchedDate);
-            if (firstPatchedPurl != null) v.getFirstPatchedPurls().add(firstPatchedPurl);
+            if (firstPatchedPurl != null) v.addFirstPatchedPurl(firstPatchedPurl);
         }
     }
 

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/VersionRanger.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/VersionRanger.java
@@ -45,6 +45,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -562,10 +563,10 @@ public class VersionRanger {
      * @param v - Vulnerability Object to filter PURLs of.
      */
     public void sortVulnerabilityPurls(Vulnerability v) {
-        var basePurl = v.getPurls().get(0).split("@")[0];
+        var basePurl = v.getPurls().stream().findFirst().orElseThrow().split("@")[0];
         var versions = getVersions(basePurl).stream().map(vrs -> basePurl + "@" + vrs).collect(Collectors.toList());
         var purlsToKeep = new HashSet<>(v.getPurls());
-        v.setPurls(versions.stream().filter(purlsToKeep::contains).collect(Collectors.toList()));
+        v.setPurls(new LinkedHashSet<>(versions.stream().filter(purlsToKeep::contains).collect(Collectors.toList())));
     }
 
     /**

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/YAMLHandler.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/mappers/YAMLHandler.java
@@ -18,11 +18,10 @@
 
 package eu.fasten.vulnerabilityproducer.utils.mappers;
 
-import com.fasterxml.jackson.annotation.*;
-import com.google.j2objc.annotations.*;
 import eu.fasten.vulnerabilityproducer.utils.Vulnerability;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 /**
@@ -808,7 +807,7 @@ public class YAMLHandler {
                     this.patched_versions.addAll(this.unaffected_versions);
 
                 var purls = vr.getVulnerablePURLsRuby(this.gem, this.patched_versions);
-                v.setPurls(purls);
+                v.setPurls(new LinkedHashSet<>(purls));
             }
             return v;
         }

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/GHParser.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/GHParser.java
@@ -168,8 +168,7 @@ public class GHParser implements VulnerabilityParser {
                     }
 
                     if (node.firstPatchedVersion != null)
-                        v.getFirstPatchedPurls().add(pgkIdentifier +
-                                "@" + node.firstPatchedVersion.identifier);
+                        v.addFirstPatchedPurl(pgkIdentifier + "@" + node.firstPatchedVersion.identifier);
                 }
             }
             // Add the vulnerability to the Hash Map

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/stats/Stats.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/stats/Stats.java
@@ -173,7 +173,7 @@ public class Stats {
         vulns.forEach(v -> {
             if (v.getPurls().size() > 0) {
                 vp.addAndGet(1);
-                var base = v.getPurls().get(0).split("@")[0];
+                var base = v.getPurls().stream().findFirst().orElseThrow().split("@")[0];
                 if (base.startsWith("pkg:maven"))    vp_mvn.addAndGet(1);
                 if (base.startsWith("pkg:pypi"))     vp_py.addAndGet(1);
                 if (base.startsWith("pkg:deb"))      vp_c.addAndGet(1);

--- a/src/test/java/eu/fasten/vulnerabilityproducer/VulnerabilityTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/VulnerabilityTest.java
@@ -18,11 +18,13 @@
 
 package eu.fasten.vulnerabilityproducer;
 
-import eu.fasten.vulnerabilityproducer.utils.*;
+import eu.fasten.vulnerabilityproducer.utils.Patch;
+import eu.fasten.vulnerabilityproducer.utils.Vulnerability;
 import eu.fasten.vulnerabilityproducer.utils.mappers.Severity;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -151,7 +153,7 @@ public class VulnerabilityTest {
         var v4 = new Vulnerability("CVE-TEST-4");
         v4.addPurl("purl5");
         v4.addPatchLink("patch2");
-        v4.setFirstPatchedPurl(new java.util.HashSet<>(java.util.Arrays.asList("purl4")));
+        v4.setFirstPatchedPurls(new java.util.LinkedHashSet<>(Collections.singletonList("purl4")));
 
         pq.add(v1);
         pq.add(v2);

--- a/src/test/java/eu/fasten/vulnerabilityproducer/mappers/VersionRangerTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/mappers/VersionRangerTest.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -547,17 +548,17 @@ public class VersionRangerTest {
                 "pkg:maven/org.apache.solr/solr-core@7.4.0",
                 "pkg:maven/org.apache.solr/solr-core@5.5.5"
         );
-        v.setPurls(purls);
+        v.setPurls(new LinkedHashSet<>(purls));
 
         vr.sortVulnerabilityPurls(v);
-        var orderedPurls = Arrays.asList(
+        var orderedPurls = new LinkedHashSet<>(Arrays.asList(
                 "pkg:maven/org.apache.solr/solr-core@6.1.0",
                 "pkg:maven/org.apache.solr/solr-core@6.4.1",
                 "pkg:maven/org.apache.solr/solr-core@7.1.0",
                 "pkg:maven/org.apache.solr/solr-core@5.5.5",
                 "pkg:maven/org.apache.solr/solr-core@7.4.0",
                 "pkg:maven/org.apache.solr/solr-core@6.6.5"
-                );
+                ));
 
         assertEquals(orderedPurls, v.getPurls());
     }


### PR DESCRIPTION
Duplicate purls can potentially slow down the producer and downstream plugins, in addition to growing data/message size needlessly.