### PR TITLE
Use Multi-threading in Vulnerability Producer

### DIFF
--- a/src/main/java/eu/fasten/vulnerabilityproducer/Main.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/Main.java
@@ -70,6 +70,12 @@ public class Main implements Runnable {
             defaultValue = "both")
     String inferStrategy;
 
+    @CommandLine.Option(names = {"-nt", "--num_threads"},
+            paramLabel = "NoOfThreadsToUse",
+            description = "Sets number of threads for gathering and parsing vulnerability data. [default=6]",
+            defaultValue = "6")
+    int noOfThreadsToUse;
+
     public static void main(String[] args) {
         final int exitCode = new CommandLine(new Main()).execute(args);
         System.exit(exitCode);
@@ -87,6 +93,7 @@ public class Main implements Runnable {
         vulnProducer.setServerAddresses(kafkaServers);
         vulnProducer.setKafkaTopic(kafkaTopic);
         vulnProducer.createKafkaProducer();
+        vulnProducer.setNumThreadsToUse(noOfThreadsToUse);
 
         if (jsonPath != null) {
             // Directly produce the vulnerabilities to the kafka topic

--- a/src/main/java/eu/fasten/vulnerabilityproducer/VulnerabilityProducer.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/VulnerabilityProducer.java
@@ -84,7 +84,8 @@ public class VulnerabilityProducer {
             logger.info("Concurrent access to cache detected - Proceeding without it.");
         }
         var ghToken = System.getenv("FASTEN_GHTOKEN");
-        this.parserManager = new ParserManager(client, this.mongoDatabase, nc, ghToken, pathToMnt, inferStrategy);
+        this.parserManager = new ParserManager(client, this.mongoDatabase, nc, ghToken, pathToMnt, inferStrategy,
+                                               kafkaProducer, topic);
     }
 
     /**
@@ -92,6 +93,7 @@ public class VulnerabilityProducer {
      */
     public void createKafkaProducer() {
         var p = KafkaConnector.kafkaProducerProperties(this.serverAddresses, groupId);
+        p.setProperty("buffer.memory", "192000000"); // 192 MB for multi-threading
         this.kafkaProducer = new KafkaProducer<>(p);
     }
 
@@ -103,7 +105,7 @@ public class VulnerabilityProducer {
     public void start(boolean updatesOnly, String inferStrategy) throws IOException {
         createParserManager(inferStrategy);
         do {
-            parserManager.getVulnerabilitiesFromParsers(kafkaProducer, topic, updatesOnly);
+            parserManager.getVulnerabilitiesFromParsers(updatesOnly);
             logger.info("Sleeping a day, see you in a bit");
             parserManager.sleep();
         } while(true);

--- a/src/main/java/eu/fasten/vulnerabilityproducer/VulnerabilityProducer.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/VulnerabilityProducer.java
@@ -49,6 +49,7 @@ public class VulnerabilityProducer {
     private ParserManager parserManager;
     private MongoDatabase mongoDatabase;
     public String pathToMnt;
+    private int maxNumThreadsToUse;
     private final Logger logger = LoggerFactory.getLogger(VulnerabilityProducer.class.getName());
 
     public void setPathToMnt(String mnt) {
@@ -70,6 +71,8 @@ public class VulnerabilityProducer {
     public void setMongoDatabase(MongoDatabase mongoDatabase) {
         this.mongoDatabase = mongoDatabase;
     }
+
+    public void setNumThreadsToUse(int numThreads) { this.maxNumThreadsToUse = numThreads; }
 
     /**
      * Sets the connection to Mongodb instance.
@@ -105,7 +108,7 @@ public class VulnerabilityProducer {
     public void start(boolean updatesOnly, String inferStrategy) throws IOException {
         createParserManager(inferStrategy);
         do {
-            parserManager.getVulnerabilitiesFromParsers(updatesOnly);
+            parserManager.getVulnerabilitiesFromParsers(updatesOnly, maxNumThreadsToUse);
             logger.info("Sleeping a day, see you in a bit");
             parserManager.sleep();
         } while(true);

--- a/src/main/java/eu/fasten/vulnerabilityproducer/db/NitriteController.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/db/NitriteController.java
@@ -52,6 +52,7 @@ public class NitriteController {
                 .openOrCreate();
         this.patchRepository = db.getRepository(PatchObject.class);
         this.vulnerabilityRepository = db.getRepository(VulnerabilityObject.class);
+        patchRepository.rebuildIndex("patchURL", true);
     }
 
     /**

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ExtraParser.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ExtraParser.java
@@ -49,18 +49,23 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
 import java.util.regex.Pattern;
 
 public class ExtraParser implements VulnerabilityParser {
 
-    private final HashMap<String, Vulnerability> vulnerabilities;
+    private final ConcurrentHashMap<String, Vulnerability> vulnerabilities;
     private final JavaHttpClient client;
     private final VersionRanger versionRanger;
     private GitHelper gitHelper;
     private final String mnt;
     private final Logger logger = LoggerFactory.getLogger(ExtraParser.class.getName());
+    private final int noParseWorkers = 6;
 
     /**
      * The same client is injected in both ExtraParser and the VersionRanger.
@@ -69,7 +74,7 @@ public class ExtraParser implements VulnerabilityParser {
      * @param client - JavaHttpClient
      */
     public ExtraParser(JavaHttpClient client, VersionRanger versionRanger, String mnt) {
-        this.vulnerabilities = new HashMap<>();
+        this.vulnerabilities = new ConcurrentHashMap<>();
         this.versionRanger = versionRanger;
         this.client = client;
         this.mnt = mnt;
@@ -81,7 +86,7 @@ public class ExtraParser implements VulnerabilityParser {
     }
 
     public HashMap<String, Vulnerability> getVulnerabilitiesInMemory() {
-        return vulnerabilities;
+        return new HashMap<>(vulnerabilities);
     }
 
     public void setGitHelper(GitHelper gitHelper) {
@@ -483,20 +488,47 @@ public class ExtraParser implements VulnerabilityParser {
     @Override
     public HashMap<String, Vulnerability> getVulnerabilities(boolean updatesOnly) {
         if(updatesOnly) return getUpdates();
-        logger.info("Parsing database from Safety-DB");
-        injectFromSafetyDB();
-        logger.info("Injecting extra commits from MSR2019 - SAP Dataset");
-        injectMSR2019SAP();
-        logger.info("Injecting statements from project-kb - SAP Research");
-        injectSAPProjectKb(mnt + "/datasets");
-        logger.info("Injecting extra commits from MSR2020 - CPP Dataset");
-        injectMSR2020CPP(mnt + "/datasets/all_c_cpp_release2.0.csv");
-        logger.info("Parsing database from cvedb");
-        injectYAMLSource("https://github.com/edoardolanzini/cvedb.git");
-        logger.info("Parsing database from victims-cve-db");
-        injectYAMLSource("https://github.com/victims/victims-cve-db.git");
+        var executor = Executors.newFixedThreadPool(noParseWorkers);
+        List<Callable<Object>> parsingTasks = new ArrayList<>();
+        parsingTasks.add(() -> {
+            logger.info("Parsing database from Safety-DB");
+            injectFromSafetyDB();
+            return null;
+        });
+        parsingTasks.add(() -> {
+            logger.info("Injecting extra commits from MSR2019 - SAP Dataset");
+            injectMSR2019SAP();
+            return null;
+        });
+        parsingTasks.add(() -> {
+            logger.info("Injecting statements from project-kb - SAP Research");
+            injectSAPProjectKb(mnt + "/datasets");
+            return null;
+        });
+        parsingTasks.add(() -> {
+            logger.info("Injecting extra commits from MSR2020 - CPP Dataset");
+            injectMSR2020CPP(mnt + "/datasets/all_c_cpp_release2.0.csv");
+            return null;
+        });
+        parsingTasks.add(() -> {
+            logger.info("Parsing database from cvedb");
+            injectYAMLSource("https://github.com/edoardolanzini/cvedb.git");
+            return null;
+        });
+        parsingTasks.add(() -> {
+            logger.info("Parsing database from victims-cve-db");
+            injectYAMLSource("https://github.com/victims/victims-cve-db.git");
+            return null;
+        });
+        try {
+            executor.invokeAll(parsingTasks);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        // Wait for the vulnerability parsers to finish their task.
+        executor.shutdown();
         logger.info("Parsed " + vulnerabilities.size() + " vulnerabilities from Extra Sources");
-        return vulnerabilities;
+        return new HashMap<>(vulnerabilities);
     }
 
     private HashMap<String, Vulnerability> getUpdates() {
@@ -507,6 +539,6 @@ public class ExtraParser implements VulnerabilityParser {
         injectYAMLSource("https://github.com/edoardolanzini/cvedb.git");
         logger.info("Parsing database from victims-cve-db");
         injectYAMLSource("https://github.com/victims/victims-cve-db.git");
-        return getUpdatedVulnerabilities(oldVulnerabilities, vulnerabilities);
+        return getUpdatedVulnerabilities(oldVulnerabilities, new HashMap<>(vulnerabilities));
     }
 }

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ExtraParser.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ExtraParser.java
@@ -104,6 +104,7 @@ public class ExtraParser implements VulnerabilityParser {
 
             var jsonObject = new JSONObject(insecureJson.trim());
             Iterator<String> keys = jsonObject.keys();
+            var insecureVulns = new HashMap<String, JSONObject>();
 
             while (keys.hasNext()) {
                 var key = keys.next();
@@ -111,26 +112,33 @@ public class ExtraParser implements VulnerabilityParser {
                 if(Objects.nonNull(listVulns)) {
                     for (Object listVuln : listVulns) {
                         var vulnObject = (JSONObject) listVuln;
-                        var cveIds = vulnObject.get("cve");
-                        if (!cveIds.toString().equals("null")) {
-                            // There are multiple CVE-IDs
-                            if (cveIds.toString().contains(",")) {
-                                var cves = cveIds.toString().split(",\\s?");
-                                Arrays.stream(cves).forEach(cve -> insertVulnerability(injectInfoHelper(key, cve, vulnObject)));
-                            } else {
-                                // There is only one CVE-ID
-                                insertVulnerability(injectInfoHelper(key, cveIds.toString(), vulnObject));
-                            }
-                        } else {
-                            // There is only PyUp-id
-                            var pyupId = (String) vulnObject.get("id");
-                            insertVulnerability(injectInfoHelper(key, pyupId, vulnObject));
-                        }
+                        insecureVulns.put(key, vulnObject);
                     }
                 }
             }
+
+            insecureVulns.keySet().parallelStream().forEach((v) -> {parseJSONVulnObj(v, insecureVulns.get(v));});
+
         } catch (Exception e) {
             e.printStackTrace();
+        }
+    }
+
+    private void parseJSONVulnObj(String key, JSONObject vulnObject) {
+        var cveIds = vulnObject.get("cve");
+        if (!cveIds.toString().equals("null")) {
+            // There are multiple CVE-IDs
+            if (cveIds.toString().contains(",")) {
+                var cves = cveIds.toString().split(",\\s?");
+                Arrays.stream(cves).forEach(cve -> insertVulnerability(injectInfoHelper(key, cve, vulnObject)));
+            } else {
+                // There is only one CVE-ID
+                insertVulnerability(injectInfoHelper(key, cveIds.toString(), vulnObject));
+            }
+        } else {
+            // There is only PyUp-id
+            var pyupId = (String) vulnObject.get("id");
+            insertVulnerability(injectInfoHelper(key, pyupId, vulnObject));
         }
     }
 

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ExtraParser.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ExtraParser.java
@@ -104,21 +104,21 @@ public class ExtraParser implements VulnerabilityParser {
 
             var jsonObject = new JSONObject(insecureJson.trim());
             Iterator<String> keys = jsonObject.keys();
-            var insecureVulns = new HashMap<String, JSONObject>();
+            var insecureVulns = new HashMap<String, List<JSONObject>>();
 
             while (keys.hasNext()) {
                 var key = keys.next();
                 var listVulns = jsonObject.optJSONArray(key);
                 if(Objects.nonNull(listVulns)) {
+                    insecureVulns.put(key, new ArrayList<>());
                     for (Object listVuln : listVulns) {
                         var vulnObject = (JSONObject) listVuln;
-                        insecureVulns.put(key, vulnObject);
+                        insecureVulns.get(key).add(vulnObject);
                     }
                 }
             }
 
-            insecureVulns.keySet().parallelStream().forEach((v) -> {parseJSONVulnObj(v, insecureVulns.get(v));});
-
+            insecureVulns.keySet().parallelStream().forEach((v) -> {insecureVulns.get(v).forEach((l) -> {parseJSONVulnObj(v, l);});});
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/NVDParser.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/NVDParser.java
@@ -53,6 +53,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
+import java.util.stream.IntStream;
 import java.util.zip.GZIPInputStream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -106,24 +109,36 @@ public class NVDParser implements VulnerabilityParser {
      * Downloads CVE json Data Feed from 2002 until current year.
      *
      * @return a list of the paths where the gzip files are stored.
-     * @throws MalformedURLException     - URL is not accessible
-     * @throws TooManyRequestsException  - too many requests are performed
-     * @throws DownloadFailedException   - download fails
-     * @throws ResourceNotFoundException - resource cannot be found
      */
-    public List<File> downloadCVEs() throws IOException,
-            TooManyRequestsException,
-            ResourceNotFoundException {
+    public List<File> downloadCVEs() {
         int currentYear = LocalDate.now().getYear();
         List<File> paths = new ArrayList<>();
-        for (int i = 2002; i <= currentYear; i++) {
-            URL cve_url = new URL("https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-" + i + ".json.gz");
-            File out_path = new File(mnt + "/nvd/nvdcve-1.1-" + i + ".json.gz");
-            Files.createDirectories(out_path.toPath().getParent());
-            logger.info("Downloading NVD file for the year " + i);
-            downloader.fetchFile(cve_url, out_path);
-            paths.add(out_path);
+        // Set 5 threads to avoid sending too many requests and download failures
+        ForkJoinPool customThreadPool = new ForkJoinPool(5);
+        try {
+            customThreadPool.submit(() -> IntStream.range(2002, currentYear + 1).parallel().forEach((i) -> {
+                URL cve_url = null;
+                File out_path = null;
+                try {
+                    cve_url = new URL("https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-" + i + ".json.gz");
+                    out_path = new File(mnt + "/nvd/nvdcve-1.1-" + i + ".json.gz");
+                    Files.createDirectories(out_path.toPath().getParent());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+                logger.info("Downloading NVD file for the year " + i);
+                try {
+                    downloader.fetchFile(cve_url, out_path);
+                } catch (DownloadFailedException | TooManyRequestsException | ResourceNotFoundException e) {
+                    // This prevents NPE later on when one of the files couldn't be downloaded
+                    logger.error("Failed to download " + cve_url);
+                }
+                paths.add(out_path);
+            })).get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
         }
+        customThreadPool.shutdownNow();
         return paths;
     }
 
@@ -216,15 +231,12 @@ public class NVDParser implements VulnerabilityParser {
 
         HashMap<String, Vulnerability> vulnerabilities = new HashMap<>();
         List<File> paths = null;
-        try {
-            // Facilitates testing since you inject it beforehand
-            if (this.downloader == null) {
-                this.downloader = new Downloader(new Settings(new Properties()));
-            }
-            paths = downloadCVEs();
-        } catch (TooManyRequestsException | ResourceNotFoundException | IOException e) {
-            e.printStackTrace();
+        // Facilitates testing since you inject it beforehand
+        if (this.downloader == null) {
+            this.downloader = new Downloader(new Settings(new Properties()));
         }
+        paths = downloadCVEs();
+
         List<DefCveItem> rawCves = new ArrayList<>();
         for (File path : paths) {
             try {

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/NVDParser.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/NVDParser.java
@@ -53,6 +53,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.stream.IntStream;
@@ -229,7 +230,7 @@ public class NVDParser implements VulnerabilityParser {
     public HashMap<String, Vulnerability> getVulnerabilities(boolean updatesOnly) {
         if(updatesOnly) return getUpdates();
 
-        HashMap<String, Vulnerability> vulnerabilities = new HashMap<>();
+        ConcurrentHashMap<String, Vulnerability> vulnerabilities = new ConcurrentHashMap<>();
         List<File> paths = null;
         // Facilitates testing since you inject it beforehand
         if (this.downloader == null) {
@@ -245,13 +246,14 @@ public class NVDParser implements VulnerabilityParser {
                 e.printStackTrace();
             }
         }
-        for (DefCveItem item : rawCves) {
-            Vulnerability v = parseVulnerability(item);
+
+        rawCves.parallelStream().forEach((c) -> {
+            Vulnerability v = parseVulnerability(c);
             vulnerabilities.put(v.getId(), v);
-        }
+        });
 
         logger.info("Parsed " + vulnerabilities.size() + " vulnerabilities from NVD");
-        return vulnerabilities;
+        return new HashMap<>(vulnerabilities);
     }
 
     /**

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/OVALParser.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/OVALParser.java
@@ -37,16 +37,18 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This parser handles all OVAL imports.
  */
 public class OVALParser implements VulnerabilityParser {
 
-    private final HashMap<String, Vulnerability> vulnerabilities;
+    private final ConcurrentHashMap<String, Vulnerability> vulnerabilities;
     private final JavaHttpClient client;
     private final VersionRanger versionRanger;
     private final Logger logger = LoggerFactory.getLogger(OVALParser.class.getName());
@@ -58,7 +60,7 @@ public class OVALParser implements VulnerabilityParser {
      * @param client - JavaHttpClient
      */
     public OVALParser(JavaHttpClient client, VersionRanger versionRanger) {
-        this.vulnerabilities = new HashMap<>();
+        this.vulnerabilities = new ConcurrentHashMap<>();
         this.versionRanger = versionRanger;
         this.client = client;
     }
@@ -68,12 +70,13 @@ public class OVALParser implements VulnerabilityParser {
      * @return - map of vulnerabilities
      */
     public HashMap<String, Vulnerability> getVulnerabilitiesInMemory() {
-        return vulnerabilities;
+        return new HashMap<>(vulnerabilities);
     }
 
     /**
      * The main source of information to get vulnerabilities is Debian.
      * Here is the link to the XML file:
+     * @return
      */
     @Override
     public HashMap<String, Vulnerability> getVulnerabilities(boolean updatesOnly) {
@@ -157,52 +160,49 @@ public class OVALParser implements VulnerabilityParser {
 
         // Parse all OvalDefinitions and create vulnerability objects
         NodeList nList = document.getElementsByTagName("definition");
-
-        try (ProgressBar pb = new ProgressBar("OVALParser", nList.getLength())) {
-            for (int i = 0; i < nList.getLength(); i++) {
-                Node node = nList.item(i);
-                Element eElement = (Element) node;
-                Vulnerability vulnOVAL = new Vulnerability(getCveId(eElement));
-                String date;
-                String description;
-                if (eElement.getElementsByTagName("debian").getLength() > 0) {
-                    if (eElement.getElementsByTagName("date").getLength() > 0) {
-                        date = eElement.getElementsByTagName("date").item(0).getTextContent();
-                        vulnOVAL.setPublishedDate(date);
-                    }
-                    if (eElement.getElementsByTagName("moreinfo").getLength() > 0) {
-                        description = eElement.getElementsByTagName("moreinfo").item(0).getTextContent();
-                        vulnOVAL.setDescription(description);
-                    }
+        List<Node> nodes = new ArrayList<>();
+        for (int i = 0; i < nList.getLength(); i++) {nodes.add(nList.item(i));}
+        ProgressBar.wrap(nodes.parallelStream(), "OVALParser").forEach((node) -> {
+            Element eElement = (Element) node;
+            Vulnerability vulnOVAL = new Vulnerability(getCveId(eElement));
+            String date;
+            String description;
+            if (eElement.getElementsByTagName("debian").getLength() > 0) {
+                if (eElement.getElementsByTagName("date").getLength() > 0) {
+                    date = eElement.getElementsByTagName("date").item(0).getTextContent();
+                    vulnOVAL.setPublishedDate(date);
                 }
-                // Grab all test_ref in criterion
-                NodeList criteriaList = eElement.getElementsByTagName("criterion");
-                for (int j = 0; j < criteriaList.getLength(); j++) {
-                    Element criteria = (Element) criteriaList.item(j);
-                    String testRef = criteria.getAttribute("test_ref");
-                    // ovalTests 1 and 2 contain info about architecture and distro
-                    if (!testRef.equals("oval:org.debian.oval:tst:1") &&
-                            !testRef.equals("oval:org.debian.oval:tst:2")) {
-                        ImmutablePair<String, String> ovalTestInfo = ovalTestMap.get(testRef);
-                        String productName = ovalObjectMap.get(ovalTestInfo.left).split(" ")[0];
-                        String lessThanVersion = ovalStateMap.get(ovalTestInfo.right).substring(2);
-                        if (productName.length() > 0 && lessThanVersion.length() > 0) {
-                            // Build version range that includes the vulnerable versions
-                            List<String> allVersions = versionRanger.getVersions("pkg:deb/debian/" + productName);
-                            List<String> vulnerableVersions = versionRanger.getVulnerableVersionsOVAL(lessThanVersion,
-                                    allVersions);
-                            for (String v : vulnerableVersions) {
-                                // For now, we only handle buster distro
-                                vulnOVAL.addPurl("pkg:deb/debian/" + productName + "@" + v + "?distro=buster");
-                            }
+                if (eElement.getElementsByTagName("moreinfo").getLength() > 0) {
+                    description = eElement.getElementsByTagName("moreinfo").item(0).getTextContent();
+                    vulnOVAL.setDescription(description);
+                }
+            }
+            // Grab all test_ref in criterion
+            NodeList criteriaList = eElement.getElementsByTagName("criterion");
+            for (int j = 0; j < criteriaList.getLength(); j++) {
+                Element criteria = (Element) criteriaList.item(j);
+                String testRef = criteria.getAttribute("test_ref");
+                // ovalTests 1 and 2 contain info about architecture and distro
+                if (!testRef.equals("oval:org.debian.oval:tst:1") &&
+                        !testRef.equals("oval:org.debian.oval:tst:2")) {
+                    ImmutablePair<String, String> ovalTestInfo = ovalTestMap.get(testRef);
+                    String productName = ovalObjectMap.get(ovalTestInfo.left).split(" ")[0];
+                    String lessThanVersion = ovalStateMap.get(ovalTestInfo.right).substring(2);
+                    if (productName.length() > 0 && lessThanVersion.length() > 0) {
+                        // Build version range that includes the vulnerable versions
+                        List<String> allVersions = versionRanger.getVersions("pkg:deb/debian/" + productName);
+                        List<String> vulnerableVersions = versionRanger.getVulnerableVersionsOVAL(lessThanVersion,
+                                allVersions);
+                        for (String v : vulnerableVersions) {
+                            // For now, we only handle buster distro
+                            vulnOVAL.addPurl("pkg:deb/debian/" + productName + "@" + v + "?distro=buster");
                         }
                     }
-                    vulnerabilities.put(vulnOVAL.getId(), vulnOVAL);
                 }
-                pb.step();
+                vulnerabilities.put(vulnOVAL.getId(), vulnOVAL);
             }
-        }
-        return vulnerabilities;
+        });
+        return new HashMap<>(vulnerabilities);
     }
 
     private String getCveId(Element eElement) {

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
@@ -103,25 +103,46 @@ public class ParserManager {
             versionRanger.updateMappings();
         }
 
-        var vulnerabilities = parseVulnerabilities(updatesOnly);
-        logger.info("Filtering out vulnerabilities without a forge");
-        vulnerabilities = vulnerabilities.stream().filter(this::vulnerabilityForgeIsSupported).collect(Collectors.toList());
+        final var vulnerabilities = parseVulnerabilities(updatesOnly);
 
-        logger.info("Injecting information about Patches");
-        ProgressBar.wrap(vulnerabilities.parallelStream(), "InjectPatches").forEach((v) -> {
-            try {
-                var patchFinder = patchFinderFactory.getNewPatchFinder();
-                logger.info("Inferring purls for " + v.getId());
-                purlMapper.inferPurls(v, patchFinder);
-                logger.info("Looking for patches in references of " + v.getId());
-                patchFinder.parseReferences(v, nitriteController);
-                logger.info("Publishing " + v.getId() + " to Kafka");
-                emitKafkaMsg(v.toJson());
-                storeStatement(v);
-            } catch (Exception e) {
-                logger.error("Could NOT process " + v.getId() + "\n" + e);
-            }
+        var executor = Executors.newFixedThreadPool(2);
+        List<Callable<Object>> tasks = new ArrayList<>();
+        // Write vulnerabilities with no forge in another thread as they are many small files
+        tasks.add(() -> {
+            logger.info("Filtering out vulnerabilities without a forge and storing them to the disk");
+            var vulnerabilitiesWithNoForge = vulnerabilities.stream().filter((v) -> !vulnerabilityForgeIsSupported(v)).collect(Collectors.toList());
+            vulnerabilitiesWithNoForge.forEach((v) -> {
+                if(!vulnerabilityForgeIsSupported(v)) {
+                    storeStatement(v);
+                }
+            });
+            return null;
         });
+
+        tasks.add(() -> {
+            logger.info("Injecting information about Patches");
+            var vulnerabilitiesWithForge = vulnerabilities.stream().filter(this::vulnerabilityForgeIsSupported).collect(Collectors.toList());
+            ProgressBar.wrap(vulnerabilitiesWithForge.parallelStream(), "InjectPatches").forEach((v) -> {
+                try {
+                    var patchFinder = patchFinderFactory.getNewPatchFinder();
+                    logger.info("Inferring purls for " + v.getId());
+                    purlMapper.inferPurls(v, patchFinder);
+                    logger.info("Looking for patches in references of " + v.getId());
+                    patchFinder.parseReferences(v, nitriteController);
+                    logger.info("Publishing " + v.getId() + " to Kafka");
+                    emitKafkaMsg(v.toJson());
+                    storeStatement(v);
+                } catch (Exception e) {
+                    logger.error("Could NOT process " + v.getId() + "\n" + e);
+                }
+            });
+            return null;
+        });
+        try {
+            executor.invokeAll(tasks);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private List<Vulnerability> parseVulnerabilities(boolean updatesOnly) {

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
@@ -98,7 +98,7 @@ public class ParserManager {
         this.kafkaTopic = kafkaTopic;
     }
 
-    public void getVulnerabilitiesFromParsers(boolean updatesOnly) {
+    public void getVulnerabilitiesFromParsers(boolean updatesOnly, int numThreadsToUse) {
         if(updatesOnly) {
             logger.info("Updating Versions of Packages");
             versionRanger.updateMappings();
@@ -112,26 +112,41 @@ public class ParserManager {
         Thread smtWriter = new Thread(() -> smtQueue.forEach(this::storeStatement));
         smtWriter.start();
 
-        logger.info("Injecting information about Patches");
+        logger.info("Injecting information about Patches  using " + numThreadsToUse  + " threads");
         var vulnerabilitiesWithForge = vulnerabilities.stream().filter(this::vulnerabilityForgeIsSupported).collect(Collectors.toList());
-        ProgressBar.wrap(vulnerabilitiesWithForge.parallelStream(), "InjectPatches").forEach((v) -> {
-            try {
-                var patchFinder = patchFinderFactory.getNewPatchFinder();
-                logger.info("Inferring purls for " + v.getId());
-                purlMapper.inferPurls(v, patchFinder);
-                logger.info("Looking for patches in references of " + v.getId());
-                patchFinder.parseReferences(v, nitriteController);
-                logger.info("Publishing " + v.getId() + " to Kafka");
-                emitKafkaMsg(v.toJson());
-                smtQueue.add(v);
-            } catch (Exception e) {
-                logger.error("Could NOT process " + v.getId() + "\n" + e);
+
+        var executor = Executors.newFixedThreadPool(numThreadsToUse);
+        List<Callable<Object>> patchFindingTasks = new ArrayList<>();
+        try(ProgressBar pb = new ProgressBar("InjectPatches", vulnerabilitiesWithForge.size())) {
+            for (var v: vulnerabilitiesWithForge) {
+                patchFindingTasks.add(() -> {parsePatchesAndPublish(smtQueue, v, pb);
+                    return null;
+                });
             }
-        });
+            try {
+                executor.invokeAll(patchFindingTasks);
+                executor.shutdown();
+                smtWriter.join();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private void parsePatchesAndPublish(ConcurrentLinkedQueue<Vulnerability> smtQueue, Vulnerability v, ProgressBar pb) {
         try {
-            smtWriter.join();
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+            var patchFinder = patchFinderFactory.getNewPatchFinder();
+            logger.info("Inferring purls for " + v.getId());
+            purlMapper.inferPurls(v, patchFinder);
+            logger.info("Looking for patches in references of " + v.getId());
+            patchFinder.parseReferences(v, nitriteController);
+            logger.info("Publishing " + v.getId() + " to Kafka");
+            emitKafkaMsg(v.toJson());
+            smtQueue.add(v);
+            pb.step();
+        } catch (Exception e) {
+            logger.error("Could NOT process " + v.getId() + "\n" + e);
+            pb.step();
         }
     }
 

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
@@ -180,7 +180,8 @@ public class ParserManager {
                 try {
                     maps.add(parsingResults.get(t).get());
                 } catch (InterruptedException | ExecutionException e) {
-                    throw new RuntimeException(e);
+                    logger.error("Exception(s) occurred in one of the parsing tasks:");
+                    e.printStackTrace();
                 }
             });
             return mergeMapsOfVulnerabilities(maps);

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -104,42 +105,31 @@ public class ParserManager {
         }
 
         final var vulnerabilities = parseVulnerabilities(updatesOnly);
+        logger.info("Filtering out vulnerabilities without a forge and storing them to the disk");
+        final var smtQueue = new ConcurrentLinkedQueue<>(vulnerabilities.stream().filter((v) -> !vulnerabilityForgeIsSupported(v)).collect(Collectors.toList()));
 
-        var executor = Executors.newFixedThreadPool(2);
-        List<Callable<Object>> tasks = new ArrayList<>();
-        // Write vulnerabilities with no forge in another thread as they are many small files
-        tasks.add(() -> {
-            logger.info("Filtering out vulnerabilities without a forge and storing them to the disk");
-            var vulnerabilitiesWithNoForge = vulnerabilities.stream().filter((v) -> !vulnerabilityForgeIsSupported(v)).collect(Collectors.toList());
-            vulnerabilitiesWithNoForge.forEach((v) -> {
-                if(!vulnerabilityForgeIsSupported(v)) {
-                    storeStatement(v);
-                }
-            });
-            return null;
-        });
+        // For writing vuln. statements without blocking other threads
+        Thread smtWriter = new Thread(() -> smtQueue.forEach(this::storeStatement));
+        smtWriter.start();
 
-        tasks.add(() -> {
-            logger.info("Injecting information about Patches");
-            var vulnerabilitiesWithForge = vulnerabilities.stream().filter(this::vulnerabilityForgeIsSupported).collect(Collectors.toList());
-            ProgressBar.wrap(vulnerabilitiesWithForge.parallelStream(), "InjectPatches").forEach((v) -> {
-                try {
-                    var patchFinder = patchFinderFactory.getNewPatchFinder();
-                    logger.info("Inferring purls for " + v.getId());
-                    purlMapper.inferPurls(v, patchFinder);
-                    logger.info("Looking for patches in references of " + v.getId());
-                    patchFinder.parseReferences(v, nitriteController);
-                    logger.info("Publishing " + v.getId() + " to Kafka");
-                    emitKafkaMsg(v.toJson());
-                    storeStatement(v);
-                } catch (Exception e) {
-                    logger.error("Could NOT process " + v.getId() + "\n" + e);
-                }
-            });
-            return null;
+        logger.info("Injecting information about Patches");
+        var vulnerabilitiesWithForge = vulnerabilities.stream().filter(this::vulnerabilityForgeIsSupported).collect(Collectors.toList());
+        ProgressBar.wrap(vulnerabilitiesWithForge.parallelStream(), "InjectPatches").forEach((v) -> {
+            try {
+                var patchFinder = patchFinderFactory.getNewPatchFinder();
+                logger.info("Inferring purls for " + v.getId());
+                purlMapper.inferPurls(v, patchFinder);
+                logger.info("Looking for patches in references of " + v.getId());
+                patchFinder.parseReferences(v, nitriteController);
+                logger.info("Publishing " + v.getId() + " to Kafka");
+                emitKafkaMsg(v.toJson());
+                smtQueue.add(v);
+            } catch (Exception e) {
+                logger.error("Could NOT process " + v.getId() + "\n" + e);
+            }
         });
         try {
-            executor.invokeAll(tasks);
+            smtWriter.join();
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
@@ -176,7 +166,7 @@ public class ParserManager {
             executor.shutdown();
             logger.info("Merging all the pulled vulnerabilities");
             var maps = new ArrayList<HashMap<String, Vulnerability>>();
-            IntStream.range(0, noParseWorkers).forEachOrdered(t -> {
+            IntStream.range(0, parsingTasks.size()).forEachOrdered(t -> {
                 try {
                     maps.add(parsingResults.get(t).get());
                 } catch (InterruptedException | ExecutionException e) {

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
@@ -25,6 +25,7 @@ import eu.fasten.vulnerabilityproducer.utils.Vulnerability;
 import eu.fasten.vulnerabilityproducer.utils.connections.JavaHttpClient;
 import eu.fasten.vulnerabilityproducer.utils.mappers.PurlMapper;
 import eu.fasten.vulnerabilityproducer.utils.mappers.VersionRanger;
+import me.tongfei.progressbar.ProgressBar;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.jooq.tools.json.JSONParser;
@@ -38,8 +39,13 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * The responsibility of the ParserManager is to gather Vulnerabilities from all the parsers.
@@ -60,6 +66,7 @@ public class ParserManager {
     private final String mnt;
     private static final Map<String, String> supportedForges =
             Map.of("mvn", "pkg:maven", "PyPI", "pkg:pypi", "debian", "pkg:deb/debian");
+    private final int noParseWorkers = 5;
 
     public ParserManager(JavaHttpClient client,
                          MongoDatabase mongoDatabase,
@@ -90,29 +97,10 @@ public class ParserManager {
             versionRanger.updateMappings();
         }
 
-        logger.info("Gathering vulnerabilities from GitHub Advisories");
-        var mapFromGH = ghParser.getVulnerabilities(updatesOnly);
-        logger.info("Gathering vulnerabilities from Extra Sources");
-        var mapFromExtraSources = extraParser.getVulnerabilities(updatesOnly);
-        logger.info("Gathering vulnerabilities from NVD");
-        var mapFromNVD = nvdParser.getVulnerabilities(updatesOnly);
-        logger.info("Gathering vulnerabilities from Debian OVAL");
-        var mapFromOVAL = ovalParser.getVulnerabilities(updatesOnly);
-        logger.info("Gathering vulnerabilities from oss-fuzz-vulns");
-        var mapFromOSSFuzz = ossFuzzParser.getVulnerabilities(updatesOnly);
-
-        logger.info("Merging all the pulled vulnerabilities");
-        var maps = new ArrayList<HashMap<String, Vulnerability>>();
-        maps.add(mapFromNVD);
-        maps.add(mapFromExtraSources);
-        maps.add(mapFromGH);
-        maps.add(mapFromOVAL);
-        maps.add(mapFromOSSFuzz);
-        var vulnerabilities = mergeMapsOfVulnerabilities(maps);
+        var vulnerabilities = parseVulnerabilities(updatesOnly);
 
         logger.info("Injecting information about Patches");
-
-        vulnerabilities.forEach(v -> {
+        ProgressBar.wrap(vulnerabilities.parallelStream(), "InjectPatches").forEach((v) -> {
             try {
                 var patchFinder = patchFinderFactory.getNewPatchFinder();
                 logger.info("Inferring purls for " + v.getId());
@@ -131,6 +119,50 @@ public class ParserManager {
                 logger.error("Could NOT process " + v.getId() + "\n" + e);
             }
         });
+    }
+
+    private List<Vulnerability> parseVulnerabilities(boolean updatesOnly) {
+
+        var executor = Executors.newFixedThreadPool(noParseWorkers);
+        List<Callable<HashMap<String, Vulnerability>>> parsingTasks = new ArrayList<>();
+        parsingTasks.add(() -> {
+            logger.info("Gathering vulnerabilities from GitHub Advisories");
+            return ghParser.getVulnerabilities(updatesOnly);
+        });
+        parsingTasks.add(() -> {
+            logger.info("Gathering vulnerabilities from Extra Sources");
+            return  extraParser.getVulnerabilities(updatesOnly);
+        });
+        parsingTasks.add(() -> {
+            logger.info("Gathering vulnerabilities from NVD");
+            return nvdParser.getVulnerabilities(updatesOnly);
+        });
+        parsingTasks.add(() -> {
+            logger.info("Gathering vulnerabilities from Debian OVAL");
+            return ovalParser.getVulnerabilities(updatesOnly);
+        });
+        parsingTasks.add(() -> {
+            logger.info("Gathering vulnerabilities from oss-fuzz-vulns");
+            return ossFuzzParser.getVulnerabilities(updatesOnly);
+        });
+
+        try {
+            List<Future<HashMap<String, Vulnerability>>> parsingResults = executor.invokeAll(parsingTasks);
+            // Wait for the vulnerability parsers to finish their task.
+            executor.shutdown();
+            logger.info("Merging all the pulled vulnerabilities");
+            var maps = new ArrayList<HashMap<String, Vulnerability>>();
+            IntStream.range(0, 1).forEachOrdered(t -> {
+                try {
+                    maps.add(parsingResults.get(t).get());
+                } catch (InterruptedException | ExecutionException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            return mergeMapsOfVulnerabilities(maps);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private boolean vulnerabilityForgeIsSupported(Vulnerability v) {

--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/parsers/ParserManager.java
@@ -61,6 +61,8 @@ public class ParserManager {
     private PatchFinderFactory patchFinderFactory;
     private final VersionRanger versionRanger;
     private final NitriteController nitriteController;
+    private final KafkaProducer<String, String> kafkaProducer;
+    private final String kafkaTopic;
     private PurlMapper purlMapper;
     private final Logger logger = LoggerFactory.getLogger(ParserManager.class.getName());
     private final String mnt;
@@ -73,7 +75,9 @@ public class ParserManager {
                          NitriteController nitriteController,
                          String ghToken,
                          String mnt,
-                         String inferStrategy) throws IOException {
+                         String inferStrategy,
+                         KafkaProducer<String, String> kafkaProducer,
+                         String kafkaTopic) throws IOException {
         Files.createDirectories(Path.of(mnt, "trackers"));
         Files.createDirectories(Path.of(mnt, "datasets"));
         Files.createDirectories(Path.of(mnt, "statements"));
@@ -89,15 +93,19 @@ public class ParserManager {
         this.ghParser      = new GHParser(client, ghToken, versionRanger, mnt + "/trackers/ghcursor.txt", ghsaStore);
         this.purlMapper    = new PurlMapper(versionRanger,mnt + "/datasets/purl_maps/", inferStrategy, client);
         this.nvdParser     = new NVDParser(new JSONParser(), client, mnt);
+        this.kafkaProducer = kafkaProducer;
+        this.kafkaTopic = kafkaTopic;
     }
 
-    public void getVulnerabilitiesFromParsers(KafkaProducer<String, String> kafkaProducer, String topic, boolean updatesOnly) {
+    public void getVulnerabilitiesFromParsers(boolean updatesOnly) {
         if(updatesOnly) {
             logger.info("Updating Versions of Packages");
             versionRanger.updateMappings();
         }
 
         var vulnerabilities = parseVulnerabilities(updatesOnly);
+        logger.info("Filtering out vulnerabilities without a forge");
+        vulnerabilities = vulnerabilities.stream().filter(this::vulnerabilityForgeIsSupported).collect(Collectors.toList());
 
         logger.info("Injecting information about Patches");
         ProgressBar.wrap(vulnerabilities.parallelStream(), "InjectPatches").forEach((v) -> {
@@ -105,15 +113,10 @@ public class ParserManager {
                 var patchFinder = patchFinderFactory.getNewPatchFinder();
                 logger.info("Inferring purls for " + v.getId());
                 purlMapper.inferPurls(v, patchFinder);
-                if(vulnerabilityForgeIsSupported(v)) {
-                    logger.info("Looking for patches in references of " + v.getId());
-                    patchFinder.parseReferences(v, nitriteController);
-                    logger.info("Publishing " + v.getId() + " to Kafka");
-                    kafkaProducer.send(new ProducerRecord<>(topic, v.toJson()));
-                }
-                else {
-                    logger.info("Forge not supported for " + v.getId() + " with base purl " + "\"" + purlMapper.getPurlBase(v) + "\"");
-                }
+                logger.info("Looking for patches in references of " + v.getId());
+                patchFinder.parseReferences(v, nitriteController);
+                logger.info("Publishing " + v.getId() + " to Kafka");
+                emitKafkaMsg(v.toJson());
                 storeStatement(v);
             } catch (Exception e) {
                 logger.error("Could NOT process " + v.getId() + "\n" + e);
@@ -152,7 +155,7 @@ public class ParserManager {
             executor.shutdown();
             logger.info("Merging all the pulled vulnerabilities");
             var maps = new ArrayList<HashMap<String, Vulnerability>>();
-            IntStream.range(0, 1).forEachOrdered(t -> {
+            IntStream.range(0, noParseWorkers).forEachOrdered(t -> {
                 try {
                     maps.add(parsingResults.get(t).get());
                 } catch (InterruptedException | ExecutionException e) {
@@ -235,5 +238,13 @@ public class ParserManager {
         this.ossFuzzParser = ossFuzzParser;
         this.patchFinderFactory = patchFinderFactory;
         this.purlMapper = purlMapper;
+    }
+
+    private void emitKafkaMsg(String msg) {
+        kafkaProducer.send(new ProducerRecord<>(kafkaTopic, msg), (recordMetadata, e) -> {
+            if (e != null) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 }

--- a/src/test/java/eu/fasten/vulnerabilityproducer/parsers/ParserManagerTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/parsers/ParserManagerTest.java
@@ -50,7 +50,8 @@ public class ParserManagerTest {
     NitriteController ncMOck = Mockito.mock(NitriteController.class);
     KafkaProducer<String, String> kpMock = Mockito.mock(KafkaProducer.class);
     final String topic = "testing";
-    ParserManager pm = new ParserManager(client, dbMock, ncMOck, "mocktoken", VulnerabilityProducerTest.testmnt, "both");
+    ParserManager pm = new ParserManager(client, dbMock, ncMOck, "mocktoken", VulnerabilityProducerTest.testmnt, "both",
+                                         kpMock, topic);
     GHParser ghParserMock = Mockito.mock(GHParser.class);
     NVDParser nvdParserMock = Mockito.mock(NVDParser.class);
     OVALParser ovalParserMock = Mockito.mock(OVALParser.class);
@@ -126,7 +127,7 @@ public class ParserManagerTest {
         when(patchFinderFactoryMock.getNewPatchFinder()).thenReturn(patchFinderMock);
         when(purlMapperMock.getPurlBase(Mockito.any(Vulnerability.class))).thenReturn("pkg:pypi/django");
 
-        pm.getVulnerabilitiesFromParsers(kpMock, topic, false);
+        pm.getVulnerabilitiesFromParsers(false);
 
         // EXPECTED
         var vE1 = new Vulnerability("CVE-TEST-1");
@@ -193,7 +194,7 @@ public class ParserManagerTest {
         when(purlMapperMock.getPurlBase(Mockito.any(Vulnerability.class))).thenReturn("pkg:pypi/django");
         when(patchFinderFactoryMock.getNewPatchFinder()).thenReturn(patchFinderMock);
 
-        pm.getVulnerabilitiesFromParsers(kpMock, topic, true);
+        pm.getVulnerabilitiesFromParsers(true);
 
         // EXPECTED
         var vE1 = new Vulnerability("CVE-TEST-1");

--- a/src/test/java/eu/fasten/vulnerabilityproducer/parsers/ParserManagerTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/parsers/ParserManagerTest.java
@@ -33,6 +33,7 @@ import eu.fasten.vulnerabilityproducer.utils.parsers.NVDParser;
 import eu.fasten.vulnerabilityproducer.utils.parsers.OSSFuzzParser;
 import eu.fasten.vulnerabilityproducer.utils.parsers.OVALParser;
 import eu.fasten.vulnerabilityproducer.utils.parsers.ParserManager;
+import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.Test;
@@ -151,12 +152,12 @@ public class ParserManagerTest {
         // CVE-TEST-3
         vE3.addReference("ref_1");
 
-        verify(kpMock).send(new ProducerRecord<>(topic, vE1.toJson()));
-        verify(kpMock).send(new ProducerRecord<>(topic, vE2.toJson()));
-        verify(kpMock).send(new ProducerRecord<>(topic, vE3.toJson()));
-        verify(kpMock).send(new ProducerRecord<>(topic, vE4.toJson()));
-        verify(kpMock).send(new ProducerRecord<>(topic, vE5.toJson()));
-        verify(kpMock).send(new ProducerRecord<>(topic, vE6.toJson()));
+        verify(kpMock).send(eq(new ProducerRecord<>(topic, vE1.toJson())), any(Callback.class));
+//        verify(kpMock).send(eq(new ProducerRecord<>(topic, vE2.toJson())), any(Callback.class));
+        verify(kpMock).send(eq(new ProducerRecord<>(topic, vE3.toJson())), any(Callback.class));
+        verify(kpMock).send(eq(new ProducerRecord<>(topic, vE4.toJson())), any(Callback.class));
+        verify(kpMock).send(eq(new ProducerRecord<>(topic, vE5.toJson())), any(Callback.class));
+        verify(kpMock).send(eq(new ProducerRecord<>(topic, vE6.toJson())), any(Callback.class));
     }
 
     @Test
@@ -202,9 +203,9 @@ public class ParserManagerTest {
         var vE4 = new Vulnerability("CVE-TEST-4");
         var vE5 = new Vulnerability("OSV-2021-TEST");
 
-        verify(kpMock).send(new ProducerRecord<>(topic, vE1.toJson()));
-        verify(kpMock).send(new ProducerRecord<>(topic, vE2.toJson()));
-        verify(kpMock).send(new ProducerRecord<>(topic, vE4.toJson()));
-        verify(kpMock).send(new ProducerRecord<>(topic, vE5.toJson()));
+        verify(kpMock).send(eq(new ProducerRecord<>(topic, vE1.toJson())), any(Callback.class));
+        verify(kpMock).send(eq(new ProducerRecord<>(topic, vE2.toJson())), any(Callback.class));
+        verify(kpMock).send(eq(new ProducerRecord<>(topic, vE4.toJson())), any(Callback.class));
+        verify(kpMock).send(eq(new ProducerRecord<>(topic, vE5.toJson())), any(Callback.class));
     }
 }

--- a/src/test/java/eu/fasten/vulnerabilityproducer/parsers/ParserManagerTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/parsers/ParserManagerTest.java
@@ -128,7 +128,7 @@ public class ParserManagerTest {
         when(patchFinderFactoryMock.getNewPatchFinder()).thenReturn(patchFinderMock);
         when(purlMapperMock.getPurlBase(Mockito.any(Vulnerability.class))).thenReturn("pkg:pypi/django");
 
-        pm.getVulnerabilitiesFromParsers(false);
+        pm.getVulnerabilitiesFromParsers(false, 1);
 
         // EXPECTED
         var vE1 = new Vulnerability("CVE-TEST-1");
@@ -195,7 +195,7 @@ public class ParserManagerTest {
         when(purlMapperMock.getPurlBase(Mockito.any(Vulnerability.class))).thenReturn("pkg:pypi/django");
         when(patchFinderFactoryMock.getNewPatchFinder()).thenReturn(patchFinderMock);
 
-        pm.getVulnerabilitiesFromParsers(true);
+        pm.getVulnerabilitiesFromParsers(true, 1);
 
         // EXPECTED
         var vE1 = new Vulnerability("CVE-TEST-1");


### PR DESCRIPTION
This PR addresses #120 by using `Executors` and `ParallelStream` for gathering and parsing vulnerability data from multiple sources. The speed gain is up to 20-30 times, which is quite significant.