### PR TITLE
Consider CWE IDs and VectorCVSS scores when merging vulnerabilities

### DIFF
--- a/src/main/java/eu/fasten/vulnerabilityproducer/utils/Vulnerability.java
+++ b/src/main/java/eu/fasten/vulnerabilityproducer/utils/Vulnerability.java
@@ -326,6 +326,27 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
                 this.setLastModifiedDate(v2.lastModifiedDate);
             }
         }
+
+        // CWE IDs
+        if (this.cweIds == null) {
+            if (v2.cweIds != null) {
+                this.setCweIds(v2.cweIds);
+            }
+        }
+
+        // VectorCVSS2
+        if (this.vectorCVSS2 == null) {
+            if (v2.vectorCVSS2 != null) {
+                this.setVectorCVSS2(v2.vectorCVSS2);
+            }
+        }
+
+        // VectorCVSS3
+        if (this.vectorCVSS3 == null) {
+            if (v2.vectorCVSS3 != null) {
+                this.setVectorCVSS3(v2.vectorCVSS3);
+            }
+        }
     }
 
     @Override

--- a/src/test/java/eu/fasten/vulnerabilityproducer/VulnerabilityTest.java
+++ b/src/test/java/eu/fasten/vulnerabilityproducer/VulnerabilityTest.java
@@ -24,9 +24,9 @@ import eu.fasten.vulnerabilityproducer.utils.mappers.Severity;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.PriorityQueue;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -129,12 +129,18 @@ public class VulnerabilityTest {
         v2.addReference("www.anotherreference.com");
         v2.addPatchLink("www.patch.com");
         v2.setSeverity(Severity.CRITICAL);
+        v2.setCweIds(new ArrayList<>(Collections.singleton("CWE-23")));
+        v2.setVectorCVSS2("5.5");
+        v2.setVectorCVSS3("7.4");
 
         v1.merge(v2);
         assertTrue(v1.getPurls().contains("pgk:pypi/django@1.4"));
         assertTrue(v1.getReferences().contains("www.anotherreference.com"));
         assertTrue(v1.getPatchLinks().contains("www.patch.com"));
         assertEquals(v1.getSeverity(), Severity.CRITICAL);
+        assertEquals(v1.getCweIds(), v2.getCweIds());
+        assertEquals(v1.getVectorCVSS2(), v2.getVectorCVSS2());
+        assertEquals(v1.getVectorCVSS3(), v2.getVectorCVSS3());
     }
 
     @Test


### PR DESCRIPTION
This PR adds a small fix to consider CWE IDs and VectorCVSS scores when merging vulnerabilities. Some vulnerabilities lack this two information while they are present on the NVD website.